### PR TITLE
[feat] chip components 구현

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/Chip.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Chip.swift
@@ -114,7 +114,7 @@ final class Chip: UIView {
     private func setLayout() {
         label.snp.makeConstraints {
             $0.center.equalToSuperview()
-            $0.verticalEdges.equalToSuperview().inset(2)
+            $0.verticalEdges.equalToSuperview().inset(2.5)
             $0.horizontalEdges.equalToSuperview().inset(6)
         }
     }

--- a/HilingualPresentation/Sources/Presentation/Common/Components/Chip.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Chip.swift
@@ -1,0 +1,71 @@
+//
+//  Chip.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 7/6/25.
+//
+
+import UIKit
+
+enum ChipType {
+    case verb
+    case noun
+    case pronoun
+    case adjective
+    case adverb
+    case preposition
+    case conjunction
+    case interjection
+    case phrase
+    case clause
+    case expression
+    case me
+    case ai
+    
+    var title: String {
+        switch self {
+        case .verb: return "동사"
+        case .noun: return "명사"
+        case .pronoun: return "대명사"
+        case .adjective: return "형용사"
+        case .adverb: return "부사"
+        case .preposition: return "전치사"
+        case .conjunction: return "접속사"
+        case .interjection: return "감탄사"
+        case .phrase: return "숙어"
+        case .clause: return "속어"
+        case .expression: return "구"
+        case .me: return "me"
+        case .ai: return "AI"
+        }
+    }
+    
+    var backgroundColor: UIColor {
+        switch self {
+        case .verb: return .hilingualOrange
+        case .noun: return .noun_bg
+        case .pronoun: return .pronoun_bg
+        case .adjective: return .adj_bg
+        case .adverb: return .adverb_bg
+        case .preposition: return .preposition_bg
+        case .conjunction: return .hilingualBlue
+        case .interjection: return .interjection_bg
+        case .phrase, .clause, .expression: return .gray100
+        case .me: return .hilingualBlack
+        case .ai: return .hilingualOrange
+        }
+    }
+    
+    var textColor: UIColor {
+        switch self {
+        case .noun: return .hilingualBlue
+        case .pronoun: return .pronoun_text
+        case .adjective: return .adj_text
+        case .adverb: return .adverb_text
+        case .preposition: return .preposition_text
+        case .phrase, .clause, .expression: return .gray400
+        default:
+            return .white
+        }
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Components/Chip.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Chip.swift
@@ -119,3 +119,31 @@ final class Chip: UIView {
         }
     }
 }
+
+@available(iOS 17.0, *)
+fileprivate final class ChipPreviewViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let chip1 = Chip(type: .adjective)
+        let chip2 = Chip(type: .noun)
+        
+        view.addSubviews(chip1, chip2)
+        
+        chip1.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalTo(view.snp.centerX).offset(-4)
+        }
+        
+        chip2.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(view.snp.centerX).offset(4)
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    ChipPreviewViewController()
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Components/Chip.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Chip.swift
@@ -66,6 +66,56 @@ enum ChipType {
         case .phrase, .clause, .expression: return .gray400
         default:
             return .white
+            
+        }
+    }
+}
+
+final class Chip: UIView {
+    
+    // MARK: - Properties
+    
+    private let label: UILabel = {
+        let label = UILabel()
+        label.font = .suit(.caption_m_12)
+        label.textAlignment = .center
+        label.numberOfLines = 1
+        return label
+    }()
+    
+    // MARK: - Lifecycle
+    
+    init(type: ChipType) {
+        super.init(frame: .zero)
+        setStyle(with: type)
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup Methods
+    
+    private func setStyle(with type: ChipType) {
+        backgroundColor = type.backgroundColor
+        layer.cornerRadius = 10
+        clipsToBounds = true
+        
+        label.text = type.title
+        label.textColor = type.textColor
+    }
+    
+    private func setUI() {
+        addSubview(label)
+    }
+    
+    private func setLayout() {
+        label.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.verticalEdges.equalToSuperview().inset(2)
+            $0.horizontalEdges.equalToSuperview().inset(6)
         }
     }
 }


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [x] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [x] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [x] Approve된 PR은 Assigner가 직접 머지해주세요.
- [x] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #17 

---

## 📎 Work Description 
- Chip 컴포넌트를 구현했습니다.
- 각 품사별로 title, textColor, backgroundColor enum으로 지정해넣어주고 있습니다.
- 아래와 같이 Chip에 타입을 지정하셔서 사용해주시면 됩니다.
```
let chip1 = Chip(type: .adjective)
let chip2 = Chip(type: .noun)

view.addSubviews(chip1, chip2)

chip1.snp.makeConstraints {
    $0.centerY.equalToSuperview()
    $0.trailing.equalTo(view.snp.centerX).offset(-4)
}

chip2.snp.makeConstraints {
    $0.centerY.equalToSuperview()
    $0.leading.equalTo(view.snp.centerX).offset(4)
}
```

---

## 📷 Screenshots  

| 기능/화면 | - | - |
|:---------:|:---------:|:-------------:|
| Preview | <img src="https://github.com/user-attachments/assets/0bddeb00-2868-4648-a633-e6f86fb07645" width="250"> | <img src="https://github.com/user-attachments/assets/57e3de30-fc1c-4b9a-8abe-c70bcc2967d2" width="250"> |
---

## 💬 To Reviewers  
- GUI에 나온 크기대로 구현했는데, 폰으로 보면 생각보다 작을 것 같다는 생각입니다.
