### PR TITLE
[feat] 커스텀 텍스트필드 컴포넌트 구현

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Base/BaseUiViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Base/BaseUiViewController.swift
@@ -37,6 +37,7 @@ public class BaseUIViewController<VM: BaseViewBindable>: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
+        self.hideKeyboardWhenTappedAround()
 
         setUI()
         setLayout()

--- a/HilingualPresentation/Sources/Presentation/Common/Components/TextField.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/TextField.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  TextField.swift
 //  HilingualPresentation
 //
 //  Created by 성현주 on 7/8/25.
@@ -104,7 +104,7 @@ final class TextField: BaseUIView {
         }
     }
 
-    // MARK: - Private Methods
+    // MARK: - Custom Methods
 
     override func setUI() {
         backgroundColor = .clear
@@ -130,6 +130,8 @@ final class TextField: BaseUIView {
             $0.edges.equalToSuperview()
         }
     }
+
+    // MARK: - Private Methods
 
     private func setAction() {
         textField.addTarget(self, action: #selector(textDidChange), for: .editingChanged)

--- a/HilingualPresentation/Sources/Presentation/Common/Components/TextField.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/TextField.swift
@@ -1,0 +1,157 @@
+//
+//  File.swift
+//  HilingualPresentation
+//
+//  Created by 성현주 on 7/8/25.
+//
+
+import UIKit
+import SnapKit
+
+final class TextField: BaseUIView {
+
+    public enum State {
+        case normal
+        case error(String)
+        case success(String)
+    }
+
+    // MARK: - Public Properties
+
+    var maxLength: Int = 10 {
+        didSet {
+            updateCharacterCount()
+        }
+    }
+
+    var text: String {
+        return textField.text ?? ""
+    }
+
+    // MARK: - UI Components
+
+    let textField:  UITextField = {
+        let textField = UITextField()
+        textField.font = .suit(.body_sb_16)
+        textField.borderStyle = .none
+        textField.layer.cornerRadius = 8
+        textField.layer.borderWidth = 1
+        textField.backgroundColor = .gray100
+        return textField
+    }()
+
+    private let messageLabel: UILabel = {
+        let label = UILabel()
+        label.font = .suit(.caption_r_12)
+        label.textColor = .systemRed
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private lazy var characterCountLabel:  UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14)
+        label.textColor = .lightGray
+        label.text = "0/\(maxLength)"
+        return label
+    }()
+
+    private let messageStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 4
+        stack.distribution = .equalSpacing
+        return stack
+    }()
+
+    private let mainStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 8
+        return stack
+    }()
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        updateState(.normal)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public Methods
+
+    func setPlaceholder(_ text: String) {
+        textField.placeholder = text
+    }
+
+    func updateState(_ state: State) {
+        switch state {
+        case .normal:
+            textField.layer.borderColor = UIColor.clear.cgColor
+            messageLabel.text = ""
+        case .error(let message):
+            textField.layer.borderColor = UIColor.systemRed.cgColor
+            messageLabel.text = message
+            messageLabel.textColor = .systemRed
+        case .success(let message):
+            textField.layer.borderColor = UIColor.clear.cgColor
+            messageLabel.text = message
+            messageLabel.textColor = .hilingualBlue
+        }
+    }
+
+    // MARK: - Private Methods
+
+    override func setUI() {
+        backgroundColor = .clear
+        addSubview(mainStack)
+
+        mainStack.addArrangedSubview(textField)
+        mainStack.addArrangedSubview(messageStack)
+
+        messageStack.addArrangedSubview(messageLabel)
+        messageStack.addArrangedSubview(characterCountLabel)
+
+        textField.addTarget(self, action: #selector(textDidChange), for: .editingChanged)
+
+        addTextPadding()
+    }
+
+    override func setLayout() {
+        textField.snp.makeConstraints {
+            $0.height.equalTo(54)
+        }
+
+        mainStack.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+
+    private func setAction() {
+        textField.addTarget(self, action: #selector(textDidChange), for: .editingChanged)
+
+    }
+
+    private func updateCharacterCount() {
+        characterCountLabel.text = "\(text.count)/\(maxLength)"
+    }
+
+    private func addTextPadding() {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: 0))
+        textField.leftView = paddingView
+        textField.leftViewMode = .always
+    }
+
+    @objc
+    private func textDidChange() {
+        let current = textField.text ?? ""
+        if current.count > maxLength {
+            textField.text = String(current.prefix(maxLength))
+        }
+        updateCharacterCount()
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/UIViewController+.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/UIViewController+.swift
@@ -1,0 +1,22 @@
+//
+//  UIViewController+.swift
+//  HilingualPresentation
+//
+//  Created by 성현주 on 7/8/25.
+//
+
+import UIKit
+
+extension UIViewController {
+
+    /// 키보드 위 화면 터치 시, 키보드 내리기
+    func hideKeyboardWhenTappedAround() {
+        let tapped = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        tapped.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapped)
+    }
+
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Login/LoginView.swift
+++ b/HilingualPresentation/Sources/Presentation/Login/LoginView.swift
@@ -18,6 +18,11 @@ final class LoginView: UIView {
         return button
     }()
 
+    let customTextfield: TextField = {
+        let textfield = TextField()
+        return textfield
+    }()
+
     // MARK: - Init
 
     override init(frame: CGRect) {
@@ -33,10 +38,15 @@ final class LoginView: UIView {
     // MARK: - Layout
 
     private func setupLayout() {
-        addSubview(loginButton)
+        addSubviews(loginButton, customTextfield)
 
         loginButton.snp.makeConstraints {
             $0.center.equalToSuperview()
+        }
+        customTextfield.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.top.equalTo(loginButton.snp.bottom)
         }
     }
 }

--- a/HilingualPresentation/Sources/Presentation/Login/LoginViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Login/LoginViewController.swift
@@ -11,11 +11,8 @@ import Combine
 
 public final class LoginViewController: BaseUIViewController<LoginViewModel> {
 
-    // MARK: - Properties
-
     private let loginview = LoginView()
-
-    // MARK: - Custom Method
+    private let nicknameSubject = PassthroughSubject<String, Never>()
 
     public override func setUI() {
         view.addSubviews(loginview)
@@ -27,11 +24,16 @@ public final class LoginViewController: BaseUIViewController<LoginViewModel> {
         }
     }
 
-    // MARK: - Bind
-
     public override func bind(viewModel: LoginViewModel) {
+        loginview.customTextfield.textField.addTarget(
+            self,
+            action: #selector(nicknameDidChange),
+            for: .editingChanged
+        )
+
         let input = LoginViewModel.Input(
-            loginButtonTapped: loginview.loginButton.publisher(for: .touchUpInside)
+            loginButtonTapped: loginview.loginButton.publisher(for: .touchUpInside),
+            nicknameChanged: nicknameSubject.eraseToAnyPublisher()
         )
 
         let output = viewModel.transform(input: input)
@@ -43,5 +45,15 @@ public final class LoginViewController: BaseUIViewController<LoginViewModel> {
                 self.navigationController?.pushViewController(homeVC, animated: true)
             }
             .store(in: &cancellables)
+
+        output.nicknameState
+            .sink { [weak self] state in
+                self?.loginview.customTextfield.updateState(state)
+            }
+            .store(in: &cancellables)
+    }
+
+    @objc private func nicknameDidChange() {
+        nicknameSubject.send(loginview.customTextfield.text)
     }
 }

--- a/HilingualPresentation/Sources/Presentation/Login/LoginViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/Login/LoginViewModel.swift
@@ -14,19 +14,17 @@ public final class LoginViewModel: BaseViewModel {
 
     public struct Input {
         let loginButtonTapped: AnyPublisher<Void, Never>
+        let nicknameChanged: AnyPublisher<String, Never>
     }
 
     public struct Output {
         let navigateToHome: AnyPublisher<Void, Never>
+        let nicknameState: AnyPublisher<TextField.State, Never>
     }
+
+    // MARK: - Subjects
 
     private let navigateToHomeSubject = PassthroughSubject<Void, Never>()
-
-    // MARK: - Init
-
-    public override init() {
-        super.init()
-    }
 
     // MARK: - Transform
 
@@ -37,6 +35,24 @@ public final class LoginViewModel: BaseViewModel {
             }
             .store(in: &cancellables)
 
-        return Output(navigateToHome: navigateToHomeSubject.eraseToAnyPublisher())
+        let nicknameState = input.nicknameChanged
+            .removeDuplicates()
+            .map { nickname -> TextField.State in
+                if nickname.isEmpty {
+                    return .normal
+                } else if nickname.count < 2 {
+                    return .error("2자 이상 입력해주세요")
+                } else if nickname == "sereal" {
+                    return .error("사용할 수 없는 닉네임입니다")
+                } else {
+                    return .success("사용 가능한 닉네임이에요!")
+                }
+            }
+            .eraseToAnyPublisher()
+
+        return Output(
+            navigateToHome: navigateToHomeSubject.eraseToAnyPublisher(),
+            nicknameState: nicknameState
+        )
     }
 }

--- a/HilingualPresentation/Sources/Presentation/Login/LoginViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/Login/LoginViewModel.swift
@@ -35,6 +35,7 @@ public final class LoginViewModel: BaseViewModel {
             }
             .store(in: &cancellables)
 
+        //TODO: - 도메인 모듈에 위치
         let nicknameState = input.nicknameChanged
             .removeDuplicates()
             .map { nickname -> TextField.State in


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [x] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [x] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #33 

---

## 📎 Work Description 
- 온보딩에서 닉네임 확인에 쓰일 텍스트필드 컴포넌트를 제작했습니다. 
- 타입은 크기 . none, .error(string), .sucess(string) 이렇게 3가지로 추상화했습니다. 텍스트필드 내의 상태를 뷰모델에서 처리해서, 업데이트 하도록했습니다
- 정규식 로직의 경우에는 전 도메인 로직이라 판단하여 도메인 모듈로 위치할 예정입니다 
- loginview에 임시로 텍스트필드 위치시켜뒀습니다. 로그인 기능 구현하면서 이동 시키겠습니다
- 뷰컨에서 자동으로 키보드 활성화 비활성화 코드 추가했습니다
- 외부와 노출되는 값은, 텍스트필드의 텍스트, 최데 글자수, 그리고 텍스트필드의 상태인 state 구조체입니다.

https://github.com/user-attachments/assets/69718d06-d961-4263-80e5-37594675a687

---

## 📷 Screenshots  

| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| A 기능 | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |

---

## 💬 To Reviewers  
- 로그인뷰에 있는 코드는 임시코드입니다 무시해주세요~! 로그인 구현하면서 지울게요!
- 색이 적용이 안됩니다.. 확인해주세요 
