### PR TITLE
[chore] WordCard 컴포넌트 레이아웃 및 내부 로직 수정

### DIFF
--- a/HilingualDomain/Sources/HilingualDomain/Entity/PhraseEntity.swift
+++ b/HilingualDomain/Sources/HilingualDomain/Entity/PhraseEntity.swift
@@ -1,0 +1,26 @@
+//
+//  PhraseEntity.swift
+//  HilingualDomain
+//
+//  Created by 진소은 on 7/14/25.
+//
+
+
+struct PhraseEntity {
+    let code: Int
+    let data: PhraseData
+    let message: String
+
+    struct PhraseData {
+        let phraseList: PhraseList
+    }
+
+    struct PhraseList {
+        let phraseId: Int64
+        let phraseType: [String]
+        let phrase: String
+        let explanation: String
+        let reason: String
+        let isMarked: Bool
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Components/WordCard.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/WordCard.swift
@@ -1,15 +1,12 @@
+//
+//  WordCard.swift
+//  HilingualPresentation
+//
+//  Created by 진소은 on 7/8/25.
+//
+
 import UIKit
 import SnapKit
-
-struct PhraseData {
-    let phraseId: Int
-    let phraseType: [String]
-    let phrase: String
-    let explanation: String
-    let example: String?
-    let isMarked: Bool
-    let created_at: String?
-}
 
 enum WordCardType {
     case basic
@@ -18,38 +15,39 @@ enum WordCardType {
 }
 
 final class WordCard: UIView {
-    
+
     // MARK: - UI Components
-    
+
     private let chipStackView = UIStackView()
     private let phraseLabel = UILabel()
     private let explanationLabel = UILabel()
     private let savedDateLabel = UILabel()
-    private let exampleLabel = UILabel()
+    private let reasonLabel = UILabel()
     private let bookmarkButton = UIButton(type: .custom)
-    
+
     // MARK: - State
-    
+
     private var isMarked: Bool = false
     var onBookmarkToggled: ((Bool) -> Void)?
-    
+
     // MARK: - Init
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setUI()
         setLayout()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Configure
-    
-    func configure(type: WordCardType, data: PhraseData) {
+
+    func configure(type: WordCardType, data: PhraseData.PhraseList) {
         isMarked = data.isMarked
         
+        // Chip 초기화 및 추가
         chipStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
         data.phraseType.compactMap { chipType(from: $0) }
             .map { Chip(type: $0) }
@@ -57,26 +55,30 @@ final class WordCard: UIView {
         
         phraseLabel.text = data.phrase
         explanationLabel.text = data.explanation
+        savedDateLabel.text = "\(data.createdAt) 일기에서 저장됨"
+        reasonLabel.isHidden = data.reason.isEmpty
+        reasonLabel.text = "\(data.reason)"
+        
         updateBookmarkImage()
         
         explanationLabel.isHidden = false
-        exampleLabel.isHidden = false
+        reasonLabel.isHidden = false
         savedDateLabel.isHidden = false
         
         phraseLabel.snp.removeConstraints()
         explanationLabel.snp.removeConstraints()
-        exampleLabel.snp.removeConstraints()
+        reasonLabel.snp.removeConstraints()
         savedDateLabel.snp.removeConstraints()
         
         switch type {
         case .basic:
             phraseLabel.font = .suit(.head_m_18)
             explanationLabel.isHidden = true
-            exampleLabel.isHidden = true
+            reasonLabel.isHidden = true
             savedDateLabel.isHidden = true
             
-            phraseLabel.snp.makeConstraints {
-                $0.top.equalTo(chipStackView.snp.bottom).offset(8)
+            phraseLabel.snp.remakeConstraints {
+                $0.top.equalTo(chipStackView.snp.bottom).offset(4)
                 $0.leading.trailing.equalToSuperview().inset(12)
                 $0.bottom.equalToSuperview().inset(12)
             }
@@ -84,105 +86,104 @@ final class WordCard: UIView {
         case .withExample:
             phraseLabel.font = .suit(.body_sb_16)
             explanationLabel.font = .suit(.body_b_14)
+            reasonLabel.font = .suit(.caption_m_12)
             
-            exampleLabel.isHidden = data.example == nil
-            exampleLabel.text = data.example.map { "\"\($0)\"" }
             savedDateLabel.isHidden = true
             
             phraseLabel.snp.makeConstraints {
-                $0.top.equalTo(chipStackView.snp.bottom).offset(8)
+                $0.top.equalTo(chipStackView.snp.bottom).offset(4)
                 $0.leading.trailing.equalToSuperview().inset(12)
             }
+            
             explanationLabel.snp.makeConstraints {
                 $0.top.equalTo(phraseLabel.snp.bottom).offset(4)
                 $0.leading.trailing.equalToSuperview().inset(12)
             }
             
-            if data.example == nil {
-                explanationLabel.snp.makeConstraints {
-                    $0.bottom.equalToSuperview().inset(12)
-                }
-            } else {
-                exampleLabel.snp.makeConstraints {
-                    $0.top.equalTo(explanationLabel.snp.bottom).offset(8)
-                    $0.leading.trailing.equalToSuperview().inset(12)
-                    $0.bottom.equalToSuperview().inset(12)
-                }
+            reasonLabel.snp.makeConstraints {
+                $0.top.equalTo(explanationLabel.snp.bottom).offset(8)
+                $0.leading.trailing.equalToSuperview().inset(12)
+                $0.bottom.equalToSuperview().inset(12)
             }
             
         case .withDate:
             phraseLabel.font = .suit(.body_m_20)
             explanationLabel.font = .suit(.body_m_14)
+            savedDateLabel.font = .suit(.caption_m_12)
             
-            exampleLabel.isHidden = true
-            savedDateLabel.text = formattedCreatedDate(data.created_at)
+            reasonLabel.isHidden = true
             
             chipStackView.snp.updateConstraints {
                 $0.top.leading.equalToSuperview().inset(24)
             }
+            
             bookmarkButton.snp.updateConstraints {
                 $0.top.trailing.equalToSuperview().inset(24)
             }
             
-            phraseLabel.snp.makeConstraints {
-                $0.top.equalTo(chipStackView.snp.bottom).offset(8)
+            phraseLabel.snp.remakeConstraints {
+                $0.top.equalTo(chipStackView.snp.bottom).offset(4)
                 $0.leading.trailing.equalToSuperview().inset(24)
             }
-            explanationLabel.snp.makeConstraints {
+            
+            explanationLabel.snp.remakeConstraints {
                 $0.top.equalTo(phraseLabel.snp.bottom).offset(4)
                 $0.leading.trailing.equalToSuperview().inset(24)
             }
-            savedDateLabel.snp.makeConstraints {
+            
+            savedDateLabel.snp.remakeConstraints {
                 $0.top.equalTo(explanationLabel.snp.bottom).offset(80)
                 $0.trailing.equalToSuperview().inset(24)
                 $0.bottom.equalToSuperview().inset(40)
             }
         }
     }
-    
+
     // MARK: - Layout
-    
+
     private func setUI() {
         backgroundColor = .white
         layer.cornerRadius = 8
-        
+
         chipStackView.axis = .horizontal
         chipStackView.spacing = 4
-        
+
         explanationLabel.numberOfLines = 0
-        exampleLabel.numberOfLines = 0
-        exampleLabel.font = .suit(.caption_m_12)
-        exampleLabel.textColor = .gray700
+        reasonLabel.numberOfLines = 0
+        reasonLabel.font = .suit(.caption_m_12)
+        reasonLabel.textColor = .gray700
+
         savedDateLabel.font = .suit(.caption_m_12)
         savedDateLabel.textColor = .gray400
-        
+
         bookmarkButton.addTarget(self, action: #selector(didTapBookmark), for: .touchUpInside)
-        
-        addSubviews(chipStackView, phraseLabel, explanationLabel, savedDateLabel, exampleLabel, bookmarkButton)
+
+        addSubviews(chipStackView, phraseLabel, explanationLabel, savedDateLabel, reasonLabel, bookmarkButton)
     }
-    
+
     private func setLayout() {
         chipStackView.snp.makeConstraints {
             $0.top.leading.equalToSuperview().inset(12)
         }
+
         bookmarkButton.snp.makeConstraints {
             $0.top.trailing.equalToSuperview().inset(12)
         }
     }
-    
+
     // MARK: - Helpers
-    
+
     @objc private func didTapBookmark() {
         isMarked.toggle()
         updateBookmarkImage()
         onBookmarkToggled?(isMarked)
     }
-    
+
     private func updateBookmarkImage() {
-        let imageName = isMarked ? "ic_save_variant_28_ios" : "ic_save_default_28_ios"
+        let imageName = isMarked ? "ic_save_default_28_ios" : "ic_save_variant_28_ios"
         bookmarkButton.setImage(UIImage(named: imageName, in: .module, compatibleWith: nil), for: .normal)
     }
-    
+
     private func chipType(from korTitle: String) -> ChipType? {
         switch korTitle {
         case "동사": return .verb
@@ -200,11 +201,5 @@ final class WordCard: UIView {
         case "AI": return .ai
         default: return nil
         }
-    }
-    
-    private func formattedCreatedDate(_ createdAt: String?) -> String {
-        guard let date = createdAt else { return "" }
-        let trimmed = String(date.dropFirst(2))
-        return "\(trimmed) 일기에서 저장됨"
     }
 }

--- a/HilingualPresentation/Sources/Presentation/Diarydetail/Dummy/PhraseData.swift
+++ b/HilingualPresentation/Sources/Presentation/Diarydetail/Dummy/PhraseData.swift
@@ -1,0 +1,80 @@
+//
+//  PhraseData.swift
+//  HilingualPresentation
+//
+//  Created by 진소은 on 7/14/25.
+//
+
+struct PhraseData: Codable {
+    let code: Int
+    let data: DataContent
+    let message: String
+
+    struct DataContent: Codable {
+        let phraseList: [PhraseList]
+    }
+
+    struct PhraseList: Codable {
+        let phraseId: Int64
+        let phraseType: [String]
+        let phrase: String
+        let explanation: String
+        let reason: String
+        let createdAt: String
+        let isMarked: Bool
+    }
+}
+
+let dummyPhraseData = PhraseData(
+    code: 200,
+    data: PhraseData.DataContent(
+        phraseList: [
+            PhraseData.PhraseList(
+                phraseId: 111,
+                phraseType: ["동사", "명사"],
+                phrase: "resonate with",
+                explanation: "~와 깊이 공감되다, 마음에 와닿다",
+                reason: "“Their lyrics really resonate with me.”처럼 사용하면 감정적인 연결을 강조할 수 있어요.",
+                createdAt: "25.07.14",
+                isMarked: false
+            ),
+            PhraseData.PhraseList(
+                phraseId: 111,
+                phraseType: ["동사", "명사"],
+                phrase: "resonate with",
+                explanation: "~와 깊이 공감되다, 마음에 와닿다",
+                reason: "“Their lyrics really resonate with me.”처럼 사용하면 감정적인 연결을 강조할 수 있어요.",
+                createdAt: "25.07.14",
+                isMarked: false
+            ),
+            PhraseData.PhraseList(
+                phraseId: 111,
+                phraseType: ["동사", "명사"],
+                phrase: "resonate with",
+                explanation: "~와 깊이 공감되다, 마음에 와닿다",
+                reason: "“Their lyrics really resonate with me.”처럼 사용하면 감정적인 연결을 강조할 수 있어요.",
+                createdAt: "25.07.14",
+                isMarked: false
+            ),
+            PhraseData.PhraseList(
+                phraseId: 111,
+                phraseType: ["동사", "명사"],
+                phrase: "resonate with",
+                explanation: "~와 깊이 공감되다, 마음에 와닿다",
+                reason: "“Their lyrics really resonate with me.”처럼 사용하면 감정적인 연결을 강조할 수 있어요.",
+                createdAt: "25.07.14",
+                isMarked: false
+            ),
+            PhraseData.PhraseList(
+                phraseId: 111,
+                phraseType: ["동사", "명사"],
+                phrase: "resonate with",
+                explanation: "~와 깊이 공감되다, 마음에 와닿다",
+                reason: "“Their lyrics really resonate with me.”처럼 사용하면 감정적인 연결을 강조할 수 있어요.",
+                createdAt: "25.07.14",
+                isMarked: false
+            )
+        ]
+    ),
+    message: "추천표현 목록을 성공적으로 불러왔습니다."
+)


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [x] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #76 

---

## 📎 Work Description

WordCard 컴포넌트 레이아웃 적용이 안 되던 문제를 해결했습니다.
또한, Entity와 동일한 형식의 데이터를 받아서 바로 매핑하여 사용할 수 있도록 데이터 처리 로직을 수정했습니다.
```swift
struct PhraseData: Codable {
    let code: Int
    let data: DataContent
    let message: String

    struct DataContent: Codable {
        let phraseList: [PhraseList]
    }

    struct PhraseList: Codable {
        let phraseId: Int64
        let phraseType: [String]
        let phrase: String
        let explanation: String
        let reason: String
        let createdAt: String
        let isMarked: Bool
    }
}
```

ViewController에서 사용할 때는 `wordCard.configure(type: .basic, data: phrase)` 와 같이 호출하여 사용이 가능합니다.

```swift
private func loadDummyData() {
        let dataList = dummyPhraseData.data.phraseList
        
        dataList.forEach { phrase in
            let wordCard = WordCard()
            wordCard.configure(type: .basic, data: phrase)
            contentStackView.addArrangedSubview(wordCard)
        }
}
```

---

## 📷 Screenshots  

| 기능/화면 | Preview |
|:---------:|:---------:|
| .basic | <img width="250" src="https://github.com/user-attachments/assets/fc2e494c-c1a8-4e58-ab81-f47e9c8343e2" /> |
| .withExample | <img width="250" src="https://github.com/user-attachments/assets/eb3c194e-f733-4126-8f4d-118efeb408dd" /> |
| .withDate | <img width="250" src="https://github.com/user-attachments/assets/c4fdb729-3cfa-4528-8c0f-d9e65986690c" /> |
---

## 💬 To Reviewers  
- 혹시 또 문제가 생긴다면,,, 바로 말씀해주세요
