### PR TITLE
[chore] CTA버튼 터치영역 오류 수정

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/CTAButton.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/CTAButton.swift
@@ -21,8 +21,6 @@ final class CTAButton: UIButton {
     
     // MARK: - UI Components
     
-    private let stackView = UIStackView()
-    private let iconView = UIImageView()
     private let textLabel = UILabel()
     
     // MARK: - Lifecycle
@@ -41,7 +39,7 @@ final class CTAButton: UIButton {
         setupStyle()
         setupLayout()
         configure(with: style)
-        
+                
         self.isEnabled = autoBackground ? false : true
         
         if autoBackground {
@@ -64,50 +62,37 @@ final class CTAButton: UIButton {
     }
     
     private func setupStyle() {
-        layer.cornerRadius = 8
-        clipsToBounds = true
+            layer.cornerRadius = 8
+            clipsToBounds = true
+
+            titleLabel?.font = .suit(.body_sb_16)
+            setTitleColor(.white, for: .normal)
+            imageView?.contentMode = .scaleAspectFit
+
+            contentHorizontalAlignment = .center
+            semanticContentAttribute = .forceLeftToRight
         
-        textLabel.textColor = .white
-        textLabel.font = .suit(.body_sb_16)
-        
-        stackView.axis = .horizontal
-        stackView.spacing = 8
-        stackView.alignment = .center
-    }
-    
-    private func configure(with style: CTAButtonStyle) {
-        switch style {
-        case .TextButton(let text):
-            setupTextLabel(text)
-            
-        case .IconTextButton(let iconName, let text):
-            setupStackView(iconName: iconName, text: text)
-        }
-    }
-
-    private func setupTextLabel(_ text: String) {
-        textLabel.text = text
-        addSubview(textLabel)
-        textLabel.snp.makeConstraints {
-            $0.center.equalToSuperview()
-        }
-    }
-
-    private func setupStackView(iconName: String, text: String) {
-        iconView.image = UIImage(named: iconName, in: .module, compatibleWith: nil)
-        iconView.contentMode = .scaleAspectFit
-        iconView.snp.makeConstraints {
-            $0.width.height.equalTo(16)
+            imageEdgeInsets = UIEdgeInsets(top: 0, left: -4, bottom: 0, right: 4)
         }
 
-        textLabel.text = text
-        stackView.addArrangedSubview(iconView)
-        stackView.addArrangedSubview(textLabel)
-        addSubview(stackView)
-        stackView.snp.makeConstraints {
-            $0.center.equalToSuperview()
+        private func configure(with style: CTAButtonStyle) {
+            switch style {
+            case .TextButton(let text):
+                setTitle(text, for: .normal)
+                setImage(nil, for: .normal)
+
+            case .IconTextButton(let iconName, let text):
+                setTitle(text, for: .normal)
+
+                //아이콘 터치 이벤트 무효화 위해서
+                guard let image = UIImage(named: iconName, in: .module, compatibleWith: nil) else { return }
+
+                setImage(image, for: .normal)
+                setImage(image, for: .highlighted)
+                setImage(image, for: .selected)
+                setImage(image, for: .disabled)
+            }
         }
-    }
     
     // MARK: - Private Methods
     


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [x] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #89 

---

## 📎 Work Description 
- IconTextButton 터치영역 문제를 해결했습니다.
- 스택뷰로 지정해준 영역이 터치가 되지 않는 점을 UIButton의 기본 속성을 이용하여 수정했습니다. (Thanks to 해피)

---

## 📷 Screenshots  

https://github.com/user-attachments/assets/af6a2438-efb3-424d-9d0a-3556bdb1fbef

---

## To Reviewers

버튼 누를 때 아이콘 부분만 회색으로 변하는 기본 효과가 적용되던데, 혹시 이것보다 더 좋은 해결방법이 있다면 공유 부탁드립니다! 
```
guard let image = UIImage(named: iconName, in: .module, compatibleWith: nil) else { return }

                setImage(image, for: .normal)
                setImage(image, for: .highlighted)
                setImage(image, for: .selected)
                setImage(image, for: .disabled)
```