### PR TITLE
[chore] 카드주제 컴포넌트 레이아웃 오류 수정

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/HomeView/CardTopicView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/HomeView/CardTopicView.swift
@@ -125,6 +125,7 @@ final class CardTopicView: UIView {
         }
 
         cardStack.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(0)
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         

--- a/HilingualPresentation/Sources/Presentation/Common/Components/HomeView/SelectedInfo.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/HomeView/SelectedInfo.swift
@@ -18,9 +18,7 @@ final class SelectedInfo: UIView {
     internal let cardPreview = CardPreview()
     private let emptyDiaryView = EmptyDiaryView()
     private let diaryLockView = DiaryLockView()
-    
-    private let diaryContainerView = UIView()
-    
+        
     private let selectedDayLabel: UILabel = {
         let label = UILabel()
         label.text = ""
@@ -100,16 +98,12 @@ final class SelectedInfo: UIView {
         
         backgroundColor = .white
         
-        diaryContainerView.addSubviews(
+        addSubviews(
+            headerStack,
             cardTopicView,
             cardPreview,
             emptyDiaryView,
             diaryLockView
-        )
-
-        addSubviews(
-            headerStack,
-            diaryContainerView
         )
         
         selectedDayStack.addArrangedSubviews(
@@ -152,14 +146,11 @@ final class SelectedInfo: UIView {
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
 
-        diaryContainerView.snp.makeConstraints {
-            $0.top.equalTo(headerStack.snp.bottom).offset(12)
-            $0.horizontalEdges.bottom.equalToSuperview()
-        }
-
         [cardTopicView, cardPreview, emptyDiaryView, diaryLockView].forEach {
             $0.snp.makeConstraints {
-                $0.edges.equalToSuperview()
+                $0.top.equalTo(headerStack.snp.bottom).offset(12)
+                $0.horizontalEdges.equalToSuperview()
+                $0.bottom.equalToSuperview()
             }
         }
     }
@@ -222,7 +213,6 @@ final class SelectedInfo: UIView {
         notWrittenLabel.textColor = .gray300
         emptyDiaryView.isHidden = false
     }
-
 
     // MARK: - Helpers
     

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -92,13 +92,13 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
 
             self.homeView.selectedInfo.setSelectedDate(date)
 
-            // ✅ 일기 있는 날짜인지 판단
+            // 일기 있는 날짜인지 판단
             let isDiaryDate = self.homeView.calendarView.filledDates.contains {
                 Calendar.current.isDate($0, inSameDayAs: date)
             }
 
             if isDiaryDate {
-                // 📘 일기 조회만
+                // 일기 조회만
                 self.viewModel?.fetchDiary(for: date)
                     .receive(on: RunLoop.main)
                     .sink(receiveCompletion: { completion in
@@ -119,7 +119,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
                     })
                     .store(in: &self.viewModel!.cancellables)
             } else {
-                // 📝 주제 조회만
+                // 주제 조회만
                 self.viewModel?.fetchTopic(for: date)
                     .receive(on: RunLoop.main)
                     .sink(receiveCompletion: { completion in


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #104 

---

## 📎 Work Description 
- CardTopicView 레이아웃 오류를 수정했습니다. 
```
        cardStack.snp.makeConstraints {
            $0.top.equalToSuperview().offset(0)
            $0.horizontalEdges.equalToSuperview().inset(16)
        }
```
cardStack의 높이는 내부 콘텐츠에 따라 유동적으로 변하기 때문에, CardTopicView 전체의 높이도 함께 변화해야 합니다.
그러나 이전에는 cardStack에 상단 제약이 없어서, CardTopicView가 정확한 높이를 계산하지 못했고, 이로 인해 SelectedInfo에서 잘못된 레이아웃이 나타났습니다.
cardStack에 top 제약을 명확히 부여함으로써 높이 계산이 정상적으로 이루어지며, 해당 문제가 해결되었습니다!

---

## 📷 Screenshots  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/781ad3f6-657d-4bfe-8e76-baeddb87b950" />
