### PR TITLE
[refactor] 멘토링 피드백 반영

### DIFF
--- a/Hilingual/App/AppDIContainer.swift
+++ b/Hilingual/App/AppDIContainer.swift
@@ -59,15 +59,26 @@ final class AppDIContainer: ViewControllerFactory {
     }
     
     func makeDiaryWritingViewController(
-        topicData: (String, String)?,
+        topicData: (String, String)? = ("테스트 주제", "Test Topic"), // 임의 주제
         selectedDate: Date
     ) -> DiaryWritingViewController {
+        
+        let useCase = DummyDiaryWritingUseCase()
+        let viewModel = DiaryWritingViewModel(diaryWritingUseCase: useCase)
+        
         return DiaryWritingViewController(
-            viewModel: makeDiaryWritingViewModel(),
+            viewModel: viewModel,
             diContainer: self,
             topicData: topicData,
             selectedDate: selectedDate
         )
+        
+//        return DiaryWritingViewController(
+//            viewModel: makeDiaryWritingViewModel(),
+//            diContainer: self,
+//            topicData: topicData,
+//            selectedDate: selectedDate
+//        )
     }
 
     func makeLoadingViewController() -> HilingualPresentation.LoadingViewController {

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/DiaryWriting/DiaryWritingViewController+PHPicker.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/DiaryWriting/DiaryWritingViewController+PHPicker.swift
@@ -1,0 +1,73 @@
+//
+//  DiaryWritingViewController+PHPicker.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 7/31/25.
+//
+
+import PhotosUI
+
+// MARK: 이미지 선택
+
+extension DiaryWritingViewController: PHPickerViewControllerDelegate {
+    
+    func presentImagePicker(mode: PickerMode = .normal) {
+        currentPickerMode = mode
+        
+        var config = PHPickerConfiguration()
+        config.selectionLimit = 1
+        config.filter = .images
+        
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+    
+    public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+        
+        guard let itemProvider = results.first?.itemProvider,
+              let mode = currentPickerMode else {
+            print("사용자가 선택하지 않고 닫음")
+            return
+        }
+        
+        // 이미지 타입 로드 불가일 때는 에러 다이얼로그
+        guard itemProvider.canLoadObject(ofClass: UIImage.self) else {
+            print("❌ 이미지 로드 불가")
+            DispatchQueue.main.async {
+                self.showErrorDialog(message: "이미지를 불러올 수 없습니다.")
+            }
+            return
+        }
+        
+        itemProvider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
+            guard let self = self else { return }
+            
+            if let error = error {
+                print("❌ 이미지 로드 에러: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    self.showErrorDialog(message: "이미지 로드 중 오류가 발생했습니다.")
+                }
+                return
+            }
+            
+            guard let image = image as? UIImage else {
+                print("❌ 이미지 변환 실패")
+                DispatchQueue.main.async {
+                    self.showErrorDialog(message: "이미지를 변환할 수 없습니다.")
+                }
+                return
+            }
+            
+            DispatchQueue.main.async {
+                switch mode {
+                case .ocr:
+                    self.visionKitManager.handleOCRImage(image)
+                case .normal:
+                    self.diaryWritingView.setImage(image)
+                }
+            }
+        }
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/DiaryWriting/DiaryWritingViewController+UIImagePicker.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/DiaryWriting/DiaryWritingViewController+UIImagePicker.swift
@@ -1,0 +1,44 @@
+//
+//  DiaryWritingViewController+UIImagePicker.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 7/31/25.
+//
+
+import UIKit
+
+// MARK: 카메라 촬영
+
+extension DiaryWritingViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    
+    func presentCamera() {
+        guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
+            let alert = UIAlertController(
+                title: "카메라 사용 불가",
+                message: "카메라를 사용할 수 없습니다. 설정에서 권한을 확인해주세요.",
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "확인", style: .default))
+            present(alert, animated: true)
+            return
+        }
+
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = self
+        picker.allowsEditing = false
+        present(picker, animated: true)
+    }
+
+    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        picker.dismiss(animated: true)
+
+        if let image = info[.originalImage] as? UIImage {
+            visionKitManager.handleOCRImage(image)
+        }
+    }
+
+    public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        picker.dismiss(animated: true)
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/DiaryWriting/DiaryWritingViewController+ViewDelegate.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/DiaryWriting/DiaryWritingViewController+ViewDelegate.swift
@@ -1,0 +1,25 @@
+//
+//  DiaryWritingViewController+ViewDelegate.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 7/31/25.
+//
+
+// MARK: Delegate
+
+extension DiaryWritingViewController: DiaryWritingViewDelegate {
+    func didTapCamera() {
+        presentCamera()
+        self.diaryWritingView.modal.isHidden = true
+    }
+
+    func didTapGallery() {
+        presentImagePicker(mode: .normal) // 일반 이미지 선택기
+        self.diaryWritingView.modal.isHidden = true
+    }
+
+    func didTapOCRGallery() {
+        presentImagePicker(mode: .ocr)  // OCR용 이미지 선택기
+        self.diaryWritingView.modal.isHidden = true
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/DiaryWriting/DiaryWritingViewController+VisionKitManager.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/DiaryWriting/DiaryWritingViewController+VisionKitManager.swift
@@ -1,0 +1,19 @@
+//
+//  DiaryWritingViewController+VisionKitManager.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 7/31/25.
+//
+
+// MARK: OCR 결과, 에러 처리
+
+extension DiaryWritingViewController: VisionKitManagerDelegate {
+    func didRecognizeText(_ text: String) {
+        let limitedText = String(text.prefix(diaryWritingView.textView.maxCharacterCount))
+        diaryWritingView.setText(limitedText)
+    }
+    
+    func didFailWithError(_ message: String) {
+        showErrorDialog(title: "텍스트 스캔 에러 발생", message: message)
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
@@ -13,6 +13,13 @@ import HilingualDomain
 
 public final class DiaryWritingViewController: BaseUIViewController<DiaryWritingViewModel>, TextViewDelegate {
     
+    //MARK: - PickerMode
+    
+    enum PickerMode {
+        case normal
+        case ocr
+    }
+    
     // MARK: - Properties
     
     private let diaryWritingView = DiaryWritingView()
@@ -21,6 +28,7 @@ public final class DiaryWritingViewController: BaseUIViewController<DiaryWriting
     private let textCountSubject = PassthroughSubject<Int, Never>()
     private let topicData: (String, String)?
     private let selectedDate: Date
+    private var currentPickerMode: PickerMode?
     
     // MARK: - LifeCyccle
     
@@ -70,12 +78,32 @@ public final class DiaryWritingViewController: BaseUIViewController<DiaryWriting
     
     // MARK: - Private Methods
     
+    func showErrorDialog(title: String = "이미지 에러 발생", message: String) {
+        dialog.configure(
+            title: title,
+            content: message,
+            leftButtonTitle: "확인",
+            rightButtonTitle: "닫기"
+        )
+        
+        dialog.rightButton.removeTarget(nil, action: nil, for: .allEvents)
+        dialog.rightButton.addAction(UIAction { [weak self] _ in
+            self?.dialog.dismiss()
+        }, for: .touchUpInside)
+        
+        dialog.leftButton.removeTarget(nil, action: nil, for: .allEvents)
+        dialog.leftButton.addAction(UIAction { _ in
+            self.dialog.dismiss()
+        }, for: .touchUpInside)
+        dialog.showAnimation()
+    }
+    
     @objc private func cameraButtonTapped() {
         presentImagePicker()
     }
     
     @objc private func feedbackButtonTapped() {
-        let text = diaryWritingView.textView.text ?? ""
+        let text = diaryWritingView.textView.text
 
         let imageData: Data?
         if let image = diaryWritingView.selectedImageView.image {
@@ -180,19 +208,15 @@ public final class DiaryWritingViewController: BaseUIViewController<DiaryWriting
 
 extension DiaryWritingViewController: PHPickerViewControllerDelegate {
     
-    /// 이미지 선택기 띄우기 (OCR용 / 일반용 구분)
-    func presentImagePicker(isForOCR: Bool = false) {
+    func presentImagePicker(mode: PickerMode = .normal) {
+        currentPickerMode = mode
+        
         var config = PHPickerConfiguration()
         config.selectionLimit = 1
         config.filter = .images
         
         let picker = PHPickerViewController(configuration: config)
         picker.delegate = self
-        
-        if isForOCR {
-            picker.view.tag = 999 // OCR 식별 태그
-        }
-        
         present(picker, animated: true)
     }
     
@@ -200,26 +224,39 @@ extension DiaryWritingViewController: PHPickerViewControllerDelegate {
         picker.dismiss(animated: true)
         
         guard let itemProvider = results.first?.itemProvider,
-              itemProvider.canLoadObject(ofClass: UIImage.self) else {
+              itemProvider.canLoadObject(ofClass: UIImage.self),
+              let mode = currentPickerMode else {
             print("❌ 이미지 선택 실패 or 불러오기 불가")
+            DispatchQueue.main.async {
+                self.showErrorDialog(message: "이미지 선택 실패 또는 불러올 수 없습니다.")
+            }
             return
         }
         
         itemProvider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
+            guard let self = self else { return }
+            
             if let error = error {
                 print("❌ 이미지 로드 에러: \(error.localizedDescription)")
+                DispatchQueue.main.async {
+                    self.showErrorDialog(message: "이미지 로드 중 오류가 발생했습니다.")
+                }
                 return
             }
-            guard let self = self, let image = image as? UIImage else {
+            
+            guard let image = image as? UIImage else {
                 print("❌ 이미지 변환 실패")
+                DispatchQueue.main.async {
+                    self.showErrorDialog(message: "이미지를 변환할 수 없습니다.")
+                }
                 return
             }
             
             DispatchQueue.main.async {
-                print("✅ 이미지 선택 완료 - OCR용?: \(picker.view.tag == 999)")
-                if picker.view.tag == 999 {
+                switch mode {
+                case .ocr:
                     self.visionKitManager.handleOCRImage(image)
-                } else {
+                case .normal:
                     self.diaryWritingView.setImage(image)
                 }
             }
@@ -273,12 +310,12 @@ extension DiaryWritingViewController: DiaryWritingViewDelegate {
     }
 
     func didTapGallery() {
-        presentImagePicker(isForOCR: false) // 일반 이미지 선택기
+        presentImagePicker(mode: .normal) // 일반 이미지 선택기
         self.diaryWritingView.modal.isHidden = true
     }
 
     func didTapOCRGallery() {
-        presentImagePicker(isForOCR: true)  // OCR용 이미지 선택기
+        presentImagePicker(mode: .ocr)  // OCR용 이미지 선택기
         self.diaryWritingView.modal.isHidden = true
     }
 }
@@ -289,3 +326,4 @@ extension DiaryWritingViewController: VisionKitManagerDelegate {
         diaryWritingView.setText(limitedText)
     }
 }
+

--- a/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
@@ -224,11 +224,16 @@ extension DiaryWritingViewController: PHPickerViewControllerDelegate {
         picker.dismiss(animated: true)
         
         guard let itemProvider = results.first?.itemProvider,
-              itemProvider.canLoadObject(ofClass: UIImage.self),
               let mode = currentPickerMode else {
-            print("❌ 이미지 선택 실패 or 불러오기 불가")
+            print("사용자가 선택하지 않고 닫음")
+            return
+        }
+        
+        // 이미지 타입 로드 불가일 때는 에러 다이얼로그
+        guard itemProvider.canLoadObject(ofClass: UIImage.self) else {
+            print("❌ 이미지 로드 불가")
             DispatchQueue.main.async {
-                self.showErrorDialog(message: "이미지 선택 실패 또는 불러올 수 없습니다.")
+                self.showErrorDialog(message: "이미지를 불러올 수 없습니다.")
             }
             return
         }
@@ -324,6 +329,10 @@ extension DiaryWritingViewController: VisionKitManagerDelegate {
     func didRecognizeText(_ text: String) {
         let limitedText = String(text.prefix(diaryWritingView.textView.maxCharacterCount))
         diaryWritingView.setText(limitedText)
+    }
+    
+    func didFailWithError(_ message: String) {
+        showErrorDialog(title: "텍스트 스캔 에러 발생", message: message)
     }
 }
 

--- a/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
@@ -84,7 +84,7 @@ public final class DiaryWritingViewController: BaseUIViewController<DiaryWriting
             imageData = nil
         }
 
-        let dateString = selectedDate.toString(format: "yyyy-MM-dd")
+        let dateString = selectedDate.toFormattedString("yyyy-MM-dd")
         print("📤 postDiary 호출")
 
         let entity = DiaryWritingEntity(originalText: text, date: dateString, imageFile: imageData)
@@ -287,14 +287,5 @@ extension DiaryWritingViewController: VisionKitManagerDelegate {
     func didRecognizeText(_ text: String) {
         let limitedText = String(text.prefix(diaryWritingView.textView.maxCharacterCount))
         diaryWritingView.setText(limitedText)
-    }
-}
-
-extension Date {
-    func toString(format: String) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = format
-        formatter.locale = Locale(identifier: "ko_KR")
-        return formatter.string(from: self)
     }
 }

--- a/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
@@ -22,13 +22,13 @@ public final class DiaryWritingViewController: BaseUIViewController<DiaryWriting
     
     // MARK: - Properties
     
-    private let diaryWritingView = DiaryWritingView()
-    private let visionKitManager = VisionKitManager()
+    private(set) var diaryWritingView = DiaryWritingView()
+    private(set) var visionKitManager = VisionKitManager()
     private let dialog = Dialog()
     private let textCountSubject = PassthroughSubject<Int, Never>()
     private let topicData: (String, String)?
     private let selectedDate: Date
-    private var currentPickerMode: PickerMode?
+    var currentPickerMode: PickerMode?
     
     // MARK: - LifeCyccle
     
@@ -203,136 +203,3 @@ public final class DiaryWritingViewController: BaseUIViewController<DiaryWriting
         textCountSubject.send(count)
     }
 }
-
-// MARK: - PHPickerViewControllerDelegate + 이미지 선택기
-
-extension DiaryWritingViewController: PHPickerViewControllerDelegate {
-    
-    func presentImagePicker(mode: PickerMode = .normal) {
-        currentPickerMode = mode
-        
-        var config = PHPickerConfiguration()
-        config.selectionLimit = 1
-        config.filter = .images
-        
-        let picker = PHPickerViewController(configuration: config)
-        picker.delegate = self
-        present(picker, animated: true)
-    }
-    
-    public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
-        picker.dismiss(animated: true)
-        
-        guard let itemProvider = results.first?.itemProvider,
-              let mode = currentPickerMode else {
-            print("사용자가 선택하지 않고 닫음")
-            return
-        }
-        
-        // 이미지 타입 로드 불가일 때는 에러 다이얼로그
-        guard itemProvider.canLoadObject(ofClass: UIImage.self) else {
-            print("❌ 이미지 로드 불가")
-            DispatchQueue.main.async {
-                self.showErrorDialog(message: "이미지를 불러올 수 없습니다.")
-            }
-            return
-        }
-        
-        itemProvider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
-            guard let self = self else { return }
-            
-            if let error = error {
-                print("❌ 이미지 로드 에러: \(error.localizedDescription)")
-                DispatchQueue.main.async {
-                    self.showErrorDialog(message: "이미지 로드 중 오류가 발생했습니다.")
-                }
-                return
-            }
-            
-            guard let image = image as? UIImage else {
-                print("❌ 이미지 변환 실패")
-                DispatchQueue.main.async {
-                    self.showErrorDialog(message: "이미지를 변환할 수 없습니다.")
-                }
-                return
-            }
-            
-            DispatchQueue.main.async {
-                switch mode {
-                case .ocr:
-                    self.visionKitManager.handleOCRImage(image)
-                case .normal:
-                    self.diaryWritingView.setImage(image)
-                }
-            }
-        }
-    }
-}
-
-// MARK: - UIImagePickerControllerDelegate + 카메라 촬영기
-
-extension DiaryWritingViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-    
-    func presentCamera() {
-        guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
-            let alert = UIAlertController(
-                title: "카메라 사용 불가",
-                message: "카메라를 사용할 수 없습니다. 설정에서 권한을 확인해주세요.",
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "확인", style: .default))
-            present(alert, animated: true)
-            return
-        }
-
-        let picker = UIImagePickerController()
-        picker.sourceType = .camera
-        picker.delegate = self
-        picker.allowsEditing = false
-        present(picker, animated: true)
-    }
-
-    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-        picker.dismiss(animated: true)
-
-        if let image = info[.originalImage] as? UIImage {
-            visionKitManager.handleOCRImage(image)
-        }
-    }
-
-    public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-        picker.dismiss(animated: true)
-    }
-}
-
-// MARK: - DiaryWritingViewDelegate (카메라/갤러리 버튼 터치 이벤트)
-
-@MainActor
-extension DiaryWritingViewController: DiaryWritingViewDelegate {
-    func didTapCamera() {
-        presentCamera()
-        self.diaryWritingView.modal.isHidden = true
-    }
-
-    func didTapGallery() {
-        presentImagePicker(mode: .normal) // 일반 이미지 선택기
-        self.diaryWritingView.modal.isHidden = true
-    }
-
-    func didTapOCRGallery() {
-        presentImagePicker(mode: .ocr)  // OCR용 이미지 선택기
-        self.diaryWritingView.modal.isHidden = true
-    }
-}
-
-extension DiaryWritingViewController: VisionKitManagerDelegate {
-    func didRecognizeText(_ text: String) {
-        let limitedText = String(text.prefix(diaryWritingView.textView.maxCharacterCount))
-        diaryWritingView.setText(limitedText)
-    }
-    
-    func didFailWithError(_ message: String) {
-        showErrorDialog(title: "텍스트 스캔 에러 발생", message: message)
-    }
-}
-

--- a/HilingualPresentation/Sources/Presentation/DiaryWriting/DummyDiaryWritingUseCase.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryWriting/DummyDiaryWritingUseCase.swift
@@ -1,0 +1,23 @@
+//
+//  DummyDiaryWritingUseCase.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 7/31/25.
+//
+
+import Foundation
+import Combine
+import HilingualDomain
+
+public class DummyDiaryWritingUseCase: DiaryWritingUseCase {
+    public init() {}
+    
+    public func postDiaryWriting(_ entity: DiaryWritingEntity) -> AnyPublisher<DiaryWritingResponseEntity, Error> {
+        let mockResponse = DiaryWritingResponseEntity(diaryId: 123)
+
+        return Just(mockResponse)
+            .setFailureType(to: Error.self)
+            .delay(for: .seconds(1.5), scheduler: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/DiaryWriting/VisionKitManager.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryWriting/VisionKitManager.swift
@@ -48,7 +48,7 @@ final class VisionKitManager: NSObject {
             
             print("✅ 인식된 텍스트:\n\(recognizedText)")
             
-            Task { @MainActor in
+            Task {
                 self.delegate?.didRecognizeText(recognizedText)
             }
         } catch {

--- a/HilingualPresentation/Sources/Presentation/DiaryWriting/VisionKitManager.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryWriting/VisionKitManager.swift
@@ -12,6 +12,7 @@ import VisionKit
 @MainActor
 protocol VisionKitManagerDelegate: AnyObject {
     func didRecognizeText(_ text: String)
+    func didFailWithError(_ message: String)
 }
 
 @MainActor
@@ -30,6 +31,7 @@ final class VisionKitManager: NSObject {
     func recognizeText(from image: UIImage) {
         guard let cgImage = image.cgImage else {
             print("❌ cgImage 변환 실패")
+            delegate?.didFailWithError("이미지를 처리할 수 없습니다.")
             return
         }
         
@@ -39,6 +41,7 @@ final class VisionKitManager: NSObject {
             try handler.perform([textRecognitionRequest])
             guard let observations = textRecognitionRequest.results else {
                 print("❌ 텍스트 인식 결과가 없음")
+                delegate?.didFailWithError("텍스트를 인식할 수 없습니다.")
                 return
             }
             
@@ -46,13 +49,19 @@ final class VisionKitManager: NSObject {
                 .compactMap { $0.topCandidates(1).first?.string }
                 .joined(separator: "\n")
             
-            print("✅ 인식된 텍스트:\n\(recognizedText)")
+            if recognizedText.isEmpty {
+                print("❌ 텍스트 인식 결과가 비어 있음")
+                delegate?.didFailWithError("텍스트를 인식하지 못했습니다.")
+                return
+            }
             
+            print("✅ 인식된 텍스트:\n\(recognizedText)")
             Task {
                 self.delegate?.didRecognizeText(recognizedText)
             }
         } catch {
             print("❌ 텍스트 인식 실패: \(error.localizedDescription)")
+            delegate?.didFailWithError("텍스트 인식 중 오류가 발생했습니다.")
         }
     }
     
@@ -99,7 +108,8 @@ final class VisionKitManager: NSObject {
 }
 
 extension VisionKitManager: @preconcurrency VNDocumentCameraViewControllerDelegate {
-    @MainActor func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {
+    @MainActor
+    func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {
         controller.dismiss(animated: true) { [weak self] in
             guard scan.pageCount > 0 else { return }
             let image = scan.imageOfPage(at: 0)
@@ -107,11 +117,16 @@ extension VisionKitManager: @preconcurrency VNDocumentCameraViewControllerDelega
         }
     }
 
-    @MainActor func documentCameraViewControllerDidCancel(_ controller: VNDocumentCameraViewController) {
+    @MainActor
+    func documentCameraViewControllerDidCancel(_ controller: VNDocumentCameraViewController) {
         controller.dismiss(animated: true)
     }
 
-    @MainActor func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFailWithError error: Error) {
-        controller.dismiss(animated: true)
+    @MainActor
+    func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFailWithError error: Error) {
+        controller.dismiss(animated: true) { [weak self] in
+            print("❌ 문서 스캔 실패: \(error.localizedDescription)")
+            self?.delegate?.didFailWithError("문서를 스캔하는 중 오류가 발생했습니다.")
+        }
     }
 }


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [x] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #176 

---

## 📎 Work Description 
`DiaryWritingViewController`
- 뷰컨 내 extension로 책임 분리(이미지 선택 로직/카메라 촬영 로직/OCR 처리/UI 업데이트)하였습니다.
- OCR 식별 태그 대신 enum으로 관리하도록 하여 ocr, normal로 나누어 PickerMode를 만들었습니다.
- 에러 Dialog 처리하였습니다.

`VisionKitManager`
- @mainactor가 겹쳐져 있는 코드 삭제하였습니다.
- 에러 Dialog 처리하였습니다.

---

## 📷 Screenshots  

| 기능/화면 | 테스트 |
|:---------:|:---------:|
| 에러 처리 | <img src="https://github.com/user-attachments/assets/e84d19f8-7371-4e7c-b3e8-611f005dd245" width="250"> |


---

## 💬 To Reviewers  
- 현재 목 데이터가 들어가있는 상태입니다. 
- 멘토께서 말씀하신 ACL과 관련해, 기존 private를 internal로 변경하지말고 private(set)을 사용하라는 피드백을 반영해, extension으로 분리할 때 사용했는데요. 이를 통해 extension에서 내부 값을 읽거나 메서드를 호출할 수는(get) 있지만, set은 본체인 DiaryWritingViewController에만 가능하도록 설정해주었습니다. 
- 그러나 currentPicker 변수의 경우에는 extension에서도 값을 변경해야 하므로 internal로 변경해주었습니다.
- 에러 처리를 위한 Dialog를 재사용하면서, 두 개의 버튼이 있어야 Dialog의 모양이 잡혀서, 같은 기능의 '확인', '닫기' 버튼을  배치하였습니다. 
- 또한 더미가 들어있는 목객체가 있는 DummyDiaryWritingUseCase의 경우, 기존 UseCase와 구분을 위해, Presentation 내 DiaryWriting에 임시 배치하였으니 참고바랍니다!