### PR TITLE
[chore] DiaryDetail 내의 ImageDetail 풀프레임 이슈 대응

### DIFF
--- a/HilingualDomain/Sources/HilingualDomain/UseCase/MockUseCase/MockDiaryDetailUseCase.swift
+++ b/HilingualDomain/Sources/HilingualDomain/UseCase/MockUseCase/MockDiaryDetailUseCase.swift
@@ -14,7 +14,8 @@ public final class MockDiaryDetailUseCase: DiaryDetailUseCase {
     public func fetchDiaryDetail(diaryId: Int) -> AnyPublisher<DiaryDetailEntity, Error> {
         let dummyDetail = DiaryDetailEntity(
             date: "8월 3일 일요일",
-            image: "https://avatars.githubusercontent.com/u/42905243?v=4",
+            image: "https://cdn.discordapp.com/attachments/839608563776094232/1404184128202735636/test_image.png?ex=689a43e0&is=6898f260&hm=9f3a4d70b83e4b4742652e82c18494990030cc53a62e5d8f72fd1e2131daafd0&",
+//            image: "https://avatars.githubusercontent.com/u/42905243?v=4",
             originalText: "I goes to school every day and eat lunch with friends.",
             rewriteText: "I go to school every day and have lunch with friends.",
             diffRanges: [

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/DetailImageView.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/DetailImageView.swift
@@ -13,17 +13,18 @@ final class DetailImageView: UIView {
     // MARK: - UI Components
     
     private let imageView: UIImageView = {
-        let image = UIImageView()
-        image.image = UIImage(named: "img_load_fail_large_ios", in: .module, with: nil)
-        image.contentMode = .scaleAspectFit
-        return image
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "img_load_fail_large_ios", in: .module, with: nil)
+        imageView.contentMode = .scaleAspectFit
+        return imageView
     }()
     
     private let button: UIButton = {
-        let closeButton = UIButton(type: .system)
-        closeButton.setImage(UIImage(named: "ic_close_24_w_ios", in: .module, with: nil), for: .normal)
-        closeButton.tintColor = .white
-        return closeButton
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(named: "ic_close_24_w_ios", in: .module, with: nil), for: .normal)
+        button.tintColor = .white
+        button.addTarget(self, action: #selector(close), for: .touchUpInside)
+        return button
     }()
     
     // MARK: - LifeCycle

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/DetailImageView.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/DetailImageView.swift
@@ -13,17 +13,17 @@ final class DetailImageView: UIView {
     // MARK: - UI Components
     
     private let imageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        return imageView
+        let image = UIImageView()
+        image.image = UIImage(named: "img_load_fail_large_ios", in: .module, with: nil)
+        image.contentMode = .scaleAspectFit
+        return image
     }()
     
     private let button: UIButton = {
-        let button = UIButton(type: .system)
-        button.setImage(UIImage(named: "ic_close_24_w_ios", in: .module, with: nil), for: .normal)
-        button.tintColor = .white
-        button.addTarget(self, action: #selector(close), for: .touchUpInside)
-        return button
+        let closeButton = UIButton(type: .system)
+        closeButton.setImage(UIImage(named: "ic_close_24_w_ios", in: .module, with: nil), for: .normal)
+        closeButton.tintColor = .white
+        return closeButton
     }()
     
     // MARK: - LifeCycle
@@ -32,31 +32,72 @@ final class DetailImageView: UIView {
         super.init(frame: .zero)
         imageView.image = image
         setUI()
+        applyLayout(for: imageView.image)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - Setup Method
+    // MARK: - Setup
     
     private func setUI() {
         backgroundColor = .black
         addSubviews(imageView, button)
+        
         imageView.snp.makeConstraints {
             $0.center.equalToSuperview()
             $0.width.equalToSuperview()
+            $0.height.equalTo(imageView.snp.width).multipliedBy(16.0 / 9.0)
         }
         
         button.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide)
+            $0.top.equalTo(safeAreaLayoutGuide).inset(12)
             $0.leading.equalToSuperview().inset(12)
         }
+        
+        button.addTarget(self, action: #selector(close), for: .touchUpInside)
     }
     
-    // MARK: - Public Methods
+    // MARK: - Layout Logic
+    
+    private func applyLayout(for image: UIImage?) {
+        let target: CGFloat = 9.0 / 16.0
+        let ratio: CGFloat = {
+            guard let img = image, img.size.height > 0 else { return target }
+            return img.size.width / img.size.height
+        }()
+
+        imageView.snp.remakeConstraints {
+            $0.leading.trailing.equalToSuperview()
+
+            if ratio < target {
+                imageView.contentMode = .scaleAspectFill
+                imageView.clipsToBounds = true
+                $0.height.equalTo(imageView.snp.width).multipliedBy(16.0 / 9.0)
+                $0.bottom.equalTo(safeAreaLayoutGuide)
+            } else {
+                imageView.contentMode = .scaleAspectFit
+                imageView.clipsToBounds = false
+                $0.height.equalTo(imageView.snp.width).multipliedBy(1.0 / ratio)
+                $0.centerY.equalToSuperview()
+            }
+        }
+
+        bringSubviewToFront(button)
+        setNeedsLayout()
+        layoutIfNeeded()
+    }
+
+    func update(image: UIImage?) {
+        guard let img = image else { return }
+        imageView.image = img
+        applyLayout(for: img)
+    }
+    
+    // MARK: - Actions
     
     @objc public func close() {
-        self.removeFromSuperview()
+        removeFromSuperview()
     }
 }

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/DetailImageView.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/DetailImageView.swift
@@ -33,7 +33,6 @@ final class DetailImageView: UIView {
         super.init(frame: .zero)
         imageView.image = image
         setUI()
-        applyLayout(for: imageView.image)
     }
     
     required init?(coder: NSCoder) {
@@ -46,54 +45,54 @@ final class DetailImageView: UIView {
         backgroundColor = .black
         addSubviews(imageView, button)
         
-        imageView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.width.equalToSuperview()
-            $0.height.equalTo(imageView.snp.width).multipliedBy(16.0 / 9.0)
-        }
-        
         button.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide).inset(12)
             $0.leading.equalToSuperview().inset(12)
         }
-        
-        button.addTarget(self, action: #selector(close), for: .touchUpInside)
     }
     
     // MARK: - Layout Logic
     
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        applyLayout(for: imageView.image)
+    }
+    
     private func applyLayout(for image: UIImage?) {
+        let safe = safeAreaInsets
         let target: CGFloat = 9.0 / 16.0
         let ratio: CGFloat = {
             guard let img = image, img.size.height > 0 else { return target }
             return img.size.width / img.size.height
         }()
-
-        imageView.snp.remakeConstraints {
-            $0.leading.trailing.equalToSuperview()
-
-            if ratio < target {
-                imageView.contentMode = .scaleAspectFill
-                imageView.clipsToBounds = true
-                $0.height.equalTo(imageView.snp.width).multipliedBy(16.0 / 9.0)
-                $0.bottom.equalTo(safeAreaLayoutGuide)
-            } else {
-                imageView.contentMode = .scaleAspectFit
-                imageView.clipsToBounds = false
-                $0.height.equalTo(imageView.snp.width).multipliedBy(1.0 / ratio)
-                $0.centerY.equalToSuperview()
-            }
+        
+        let availableBounds = bounds.inset(by: safe)
+        
+        if ratio < target {
+            // 세로가 더 긴 경우: 가로를 꽉 채우는 16:9 비율, 하단 고정
+            let width = availableBounds.width
+            let height = width * (16.0 / 9.0)
+            let y = bounds.height - safe.bottom - height
+            imageView.frame = CGRect(x: 0, y: y, width: width, height: height)
+            imageView.contentMode = .scaleAspectFill
+            imageView.clipsToBounds = true
+        } else {
+            // 원본 비율 유지, 중앙 배치
+            let width = availableBounds.width
+            let height = width * (1.0 / ratio)
+            let y = (bounds.height - height) / 2.0
+            imageView.frame = CGRect(x: 0, y: y, width: width, height: height)
+            imageView.contentMode = .scaleAspectFit
+            imageView.clipsToBounds = false
         }
 
         bringSubviewToFront(button)
-        setNeedsLayout()
-        layoutIfNeeded()
     }
 
     func update(image: UIImage?) {
         guard let img = image else { return }
         imageView.image = img
-        applyLayout(for: img)
+        setNeedsLayout()
     }
     
     // MARK: - Actions


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [x] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [x] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [x] Approve된 PR은 Assigner가 직접 머지해주세요.
- [x] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #191 

---

## 📎 Work Description 
- 9:16 비율을 초과하는 사진과 초과하지 않는 사진의 분기처리를 통해 초과하는 이미지는 9:16 비율로 잘라서 화면에 보여지도록 로직을 구현
```swift
imageView.snp.remakeConstraints {
            $0.leading.trailing.equalToSuperview()

            if ratio < target {
                imageView.contentMode = .scaleAspectFill
                imageView.clipsToBounds = true
                $0.height.equalTo(imageView.snp.width).multipliedBy(16.0 / 9.0)
                $0.bottom.equalTo(safeAreaLayoutGuide)
            } else {
                imageView.contentMode = .scaleAspectFit
                imageView.clipsToBounds = false
                $0.height.equalTo(imageView.snp.width).multipliedBy(1.0 / ratio)
                $0.centerY.equalToSuperview()
            }
        }
```

---

## 📷 Screenshots  

| 기능/화면 | iPhone SE |
|:---------:|:---------:
| A 기능 | <img width= "250" src="https://github.com/user-attachments/assets/f3b40423-685c-40cd-8b8b-407aeea4ac65" /> |

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
