### PR TITLE
[feat] 공유하기 상세 프로필 컴포넌트

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/LikeCounterView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/LikeCounterView.swift
@@ -20,18 +20,18 @@ final class LikeCounterView: UIView {
     private(set) var isLiked: Bool = false {
         didSet {
             updateIcon()
-            onToggle?(likeCount, isLiked)
+            onToggle?( isLiked)
         }
     }
     
     private(set) var likeCount: Int = 0 {
         didSet {
             updateCount()
-            onToggle?(likeCount, isLiked)
+            onToggle?(isLiked)
         }
     }
     
-    var onToggle: ((Int, Bool) -> Void)?
+    var onToggle: ((Bool) -> Void)?
     
     // MARK: - UI
     

--- a/HilingualPresentation/Sources/Presentation/Common/Components/LikeCounterView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/LikeCounterView.swift
@@ -96,7 +96,7 @@ final class LikeCounterView: UIView {
                 $0.size.equalTo(24)
             }
             countLabel.snp.makeConstraints {
-                $0.top.equalTo(likeButton.snp.bottom)
+                $0.top.equalTo(likeButton.snp.bottom).offset(3)
                 $0.bottom.equalToSuperview()
                 $0.centerX.equalTo(likeButton)
             }

--- a/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
@@ -181,9 +181,7 @@ public class SharedProfileView: UIView {
                 placeholder: UIImage(named: "img_profile_normal_ios", in: .module, compatibleWith: nil)
             )
         } else {
-            profileImageView.image = UIImage(
-                named: "img_profile_normal_ios", in: .module, compatibleWith: nil
-            )
+            profileImageView.image = UIImage(named: "img_profile_normal_ios", in: .module, compatibleWith: nil)
         }
     }
 }

--- a/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
@@ -1,0 +1,131 @@
+//
+//  SharedProfileView.swift
+//  HilingualPresentation
+//
+//  Created by 진소은 on 8/20/25.
+//
+
+import UIKit
+import SnapKit
+
+public class SharedProfileView: UIView {
+    
+    // MARK: - UI Components
+    
+    private let profileImageView: UIImageView = {
+       let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 21
+        imageView.clipsToBounds = true
+        imageView.layer.borderWidth = 1
+        imageView.layer.borderColor = UIColor.gray200.cgColor
+        return imageView
+    }()
+    
+    private let infoStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 4
+        return stack
+    }()
+    
+    private let headerStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 4
+        stack.alignment = .center
+        return stack
+    }()
+    
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .suit(.head_b_16)
+        label.textColor = .gray850
+        label.numberOfLines = 1
+        return label
+    }()
+    
+    private let streakStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 0
+        stack.alignment = .center
+        return stack
+    }()
+    
+    private let streakImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage(named: "ic_fire_16_ios", in: .module, compatibleWith: nil)
+        return imageView
+    }()
+    
+    private let streakLabel: UILabel = {
+        let label = UILabel()
+        label.font = .suit(.caption_r_14)
+        return label
+    }()
+    
+    private let sharedDateLabel: UILabel = {
+        let label = UILabel()
+        label.font = .suit(.caption_r_12)
+        label.textColor = .gray500
+        return label
+    }()
+    
+    private let likeView = LikeCounterView(style: .vertical)
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - SetUI
+    
+    private func setUI() {
+        self.backgroundColor = .white
+        
+        self.addSubviews(profileImageView, infoStackView, likeView)
+        infoStackView.addArrangedSubviews(headerStackView, sharedDateLabel)
+        headerStackView.addArrangedSubviews(nameLabel, streakStackView)
+        streakStackView.addArrangedSubviews(streakImageView, streakLabel)
+    }
+    
+    private func setLayout() {
+        
+        self.snp.makeConstraints {
+            $0.height.equalTo(62)
+            $0.horizontalEdges.equalTo(safeAreaLayoutGuide.snp.horizontalEdges)
+        }
+        
+        profileImageView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(42)
+        }
+        
+        infoStackView.snp.makeConstraints {
+            $0.leading.equalTo(profileImageView.snp.trailing).offset(10)
+            $0.centerY.equalToSuperview()
+        }
+        
+        headerStackView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        sharedDateLabel.snp.makeConstraints {
+            $0.height.equalTo(15)
+        }
+        
+        likeView.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+            $0.width.equalTo(24)
+        }
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
@@ -10,6 +10,8 @@ import SnapKit
 
 public class SharedProfileView: UIView {
     
+    public var onProfileTapped: (() -> Void)?
+    
     // MARK: - UI Components
     
     private let profileImageView: UIImageView = {
@@ -79,6 +81,7 @@ public class SharedProfileView: UIView {
         super.init(frame: frame)
         setUI()
         setLayout()
+        setupGestureRecognizers()
     }
     
     required init?(coder: NSCoder) {
@@ -127,6 +130,20 @@ public class SharedProfileView: UIView {
             $0.centerY.equalToSuperview()
             $0.width.equalTo(24)
         }
+    }
+    private func setupGestureRecognizers() {
+        profileImageView.isUserInteractionEnabled = true
+        nameLabel.isUserInteractionEnabled = true
+
+        let profileTap = UITapGestureRecognizer(target: self, action: #selector(handleProfileTap))
+        let nameTap = UITapGestureRecognizer(target: self, action: #selector(handleProfileTap))
+
+        profileImageView.addGestureRecognizer(profileTap)
+        nameLabel.addGestureRecognizer(nameTap)
+    }
+
+    @objc private func handleProfileTap() {
+        onProfileTapped?()
     }
     
     public func configure(

--- a/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
@@ -11,6 +11,7 @@ import SnapKit
 public class SharedProfileView: UIView {
     
     public var onProfileTapped: (() -> Void)?
+    public var onLikeToggled: ((Bool) -> Void)?
     
     // MARK: - UI Components
     
@@ -82,6 +83,7 @@ public class SharedProfileView: UIView {
         setUI()
         setLayout()
         setupGestureRecognizers()
+        bindActions()
     }
     
     required init?(coder: NSCoder) {
@@ -131,6 +133,7 @@ public class SharedProfileView: UIView {
             $0.width.equalTo(24)
         }
     }
+    
     private func setupGestureRecognizers() {
         profileImageView.isUserInteractionEnabled = true
         nameLabel.isUserInteractionEnabled = true
@@ -140,6 +143,12 @@ public class SharedProfileView: UIView {
 
         profileImageView.addGestureRecognizer(profileTap)
         nameLabel.addGestureRecognizer(nameTap)
+    }
+    
+    private func bindActions() {
+        likeView.onToggle = { [weak self] isLiked in
+            self?.onLikeToggled?(isLiked)
+        }
     }
 
     @objc private func handleProfileTap() {

--- a/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
@@ -102,7 +102,6 @@ public class SharedProfileView: UIView {
     }
     
     private func setLayout() {
-        
         self.snp.makeConstraints {
             $0.height.equalTo(62)
             $0.horizontalEdges.equalTo(safeAreaLayoutGuide.snp.horizontalEdges)
@@ -163,7 +162,6 @@ public class SharedProfileView: UIView {
         isLiked: Bool = false,
         likeCount: Int = 0
     ) {
-        
         nameLabel.text = nickname
         
         let streakValue = max(streak, 0)
@@ -184,9 +182,7 @@ public class SharedProfileView: UIView {
             )
         } else {
             profileImageView.image = UIImage(
-                named: "img_profile_normal_ios",
-                in: .module,
-                compatibleWith: nil
+                named: "img_profile_normal_ios", in: .module, compatibleWith: nil
             )
         }
     }

--- a/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/SharedProfileView.swift
@@ -128,4 +128,40 @@ public class SharedProfileView: UIView {
             $0.width.equalTo(24)
         }
     }
+    
+    public func configure(
+        profileImageURL: String? = nil,
+        nickname: String = "이름을 입력해주세요",
+        streak: Int = 0,
+        sharedDateMinutes: Int,
+        isLiked: Bool = false,
+        likeCount: Int = 0
+    ) {
+        
+        nameLabel.text = nickname
+        
+        let streakValue = max(streak, 0)
+        streakLabel.text = "\(streakValue)"
+        streakLabel.textColor = streakValue > 0 ? .hilingualOrange : .gray400
+        
+        sharedDateLabel.text = sharedDateMinutes.timeToText + " 공유"
+        
+        likeView.configure(likeCount: likeCount, isLiked: isLiked)
+        
+        if let urlString = profileImageURL,
+           !urlString.isEmpty,
+           let url = URL(string: urlString)
+        {
+            profileImageView.kf.setImage(
+                with: url,
+                placeholder: UIImage(named: "img_profile_normal_ios", in: .module, compatibleWith: nil)
+            )
+        } else {
+            profileImageView.image = UIImage(
+                named: "img_profile_normal_ios",
+                in: .module,
+                compatibleWith: nil
+            )
+        }
+    }
 }


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [x] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [x] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [x] Approve된 PR은 Assigner가 직접 머지해주세요.
- [x] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #209 

---

## 📎 Work Description 
- 공유된 게시글에 사용되는 프로필 컴포넌트를 구현했습니다.
- 프로필 이미지 및 닉네임 터치 시 인식 가능하도록 구현했습니다.
- LikeCounterView 컴포넌트 콜백 함수를 API에서 필요한 정보만 담도록 (Int, Bool) 형식에서 (Bool)로 수정하였습니다.

View에서는 아래와 같이 사용가능합니다.
```swift
var onProfileAction: (() -> Void)?
var onLikeAction: ((Bool) -> Void)?

let profileView = SharedProfileView()

profileView.configure(profileImageURL: "https://avatars.githubusercontent.com/u/42905243?v=4", nickname: "가나디", streak: 15, sharedDateMinutes: 127, isLiked: true, likeCount: 7)

profileView.onProfileTapped = { [weak self] in
    self?.onProfileAction?()
}

profileView.onLikeToggled = { [weak self] isLiked in
    self?.onLikeAction?(isLiked)
}
```

ViewController에서는 이렇게 !
```swift
feedbackView.onProfileAction = { [weak self] in
    guard let self else { return }
    let vc = diContainer.makeWordBookViewController()
    self.navigationController?.pushViewController(vc, animated: true)
}

feedbackView.onLikeAction = { [weak self] isLiked in
    guard let self else { return }
    // 서버에 공감하기 api 호출
}
```
추후에는 해당 유저 프로필로 이동할 수 있도록 뷰컨을 연결해주면 됩니당

---

## 📷 Screenshots  
<img width="459" height="93" alt="image" src="https://github.com/user-attachments/assets/b0c6b5a8-6d87-4b7d-912c-95a0028081e1" />
---

## 💬 To Reviewers  
- LikeCounterView 컴포넌트 콜백 함수도 살짝 건드렸는데 아직 사용하신 분이 없으셔서 문제 없을 듯 합니다!
View, ViewController에서 LikeCounterView 콜백 활용하는 것도 PR에 담아뒀으니 컴포넌트 사용할 때 PR에 있는 코드 참고해서 활용하면 좋을 듯 해요
