### PR TITLE
[feat] 피드 내 검색기능 구현

### DIFF
--- a/Hilingual/App/AppDIContainer.swift
+++ b/Hilingual/App/AppDIContainer.swift
@@ -342,3 +342,13 @@ extension AppDIContainer {
     }
 }
 
+// MARK: - FeedSearchDIContainer
+
+extension AppDIContainer {
+    func makeFeedSearchViewController() -> FeedSearchViewController {
+        return FeedSearchViewController(
+            viewModel: FeedSearchViewModel(),
+            diContainer: self
+        )
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Components/FollowButton.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/FollowButton.swift
@@ -7,22 +7,20 @@
 
 import UIKit
 
+public enum FollowButtonState {
+    case follow         // 팔로우
+    case following      // 팔로잉
+    case mutualFollow   // 맞팔로우
+    case block          // 차단
+    case unblock        // 차단 해제
+}
+
+enum ButtonSize {
+    case short
+    case long
+}
+
 final class FollowButton: UIButton {
-    
-    // MARK: - Enum
-    
-    enum FollowButtonState {
-        case follow         // 팔로우
-        case following      // 팔로잉
-        case mutualFollow   // 맞팔로우
-        case block          // 차단
-        case unblock        // 차단 해제
-    }
-    
-    enum ButtonSize {
-        case short
-        case long
-    }
     
     // MARK: - Properties
     

--- a/HilingualPresentation/Sources/Presentation/Common/Components/Protocol/UserDisplayable.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Protocol/UserDisplayable.swift
@@ -1,0 +1,13 @@
+//
+//  UserDisplayable.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 8/22/25.
+//
+
+protocol UserDisplayable {
+    var userId: Int { get }
+    var profileImg: String { get }
+    var nickname: String { get }
+    var buttonState: FollowButtonState { get }
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Components/SearchBar.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/SearchBar.swift
@@ -1,0 +1,67 @@
+//
+//  SearchBar.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 8/20/25.
+//
+
+import UIKit
+import SnapKit
+
+public final class SearchBar: UISearchBar {
+
+    // MARK: - Properties
+
+    override public var placeholder: String? {
+        didSet {
+            updatePlaceholder()
+        }
+    }
+
+    // MARK: - Init
+
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        setStyle()
+    }
+
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Size
+    
+    override public var intrinsicContentSize: CGSize {
+        return CGSize(width: UIView.noIntrinsicMetric, height: 38)
+    }
+
+    // MARK: - Setup Methods
+    
+    private func setStyle() {
+        self.searchBarStyle = .minimal
+        self.searchTextField.backgroundColor = .white
+        self.searchTextField.layer.cornerRadius = 8
+        self.searchTextField.clipsToBounds = true
+        self.setImage(UIImage(named: "ic_search_20_ios", in: .module, compatibleWith: nil), for: .search, state: .normal)
+        self.setImage(UIImage(named: "ic_close_20_ios", in: .module, compatibleWith: nil), for: .clear, state: .normal)
+        self.searchTextField.attributedText = .suit(.body_m_16, text: "")
+        self.searchTextField.defaultTextAttributes[.font] = UIFont.suit(.body_m_16)
+        self.searchTextField.keyboardType = .asciiCapable
+        self.searchTextField.autocorrectionType = .no
+        self.searchTextField.autocapitalizationType = .none
+    }
+
+    private func updatePlaceholder() {
+        guard let placeholderText = placeholder else { return }
+        
+        let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor.gray400,
+            .font: UIFont.suit(.body_m_16)
+        ]
+        
+        self.searchTextField.attributedPlaceholder = NSAttributedString(
+            string: placeholderText,
+            attributes: attributes
+        )
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Components/SearchBar.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/SearchBar.swift
@@ -10,14 +10,6 @@ import SnapKit
 
 public final class SearchBar: UISearchBar {
 
-    // MARK: - Properties
-
-    override public var placeholder: String? {
-        didSet {
-            updatePlaceholder()
-        }
-    }
-
     // MARK: - Init
 
     override public init(frame: CGRect) {
@@ -27,12 +19,6 @@ public final class SearchBar: UISearchBar {
 
     required public init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - Size
-    
-    override public var intrinsicContentSize: CGSize {
-        return CGSize(width: UIView.noIntrinsicMetric, height: 38)
     }
 
     // MARK: - Setup Methods
@@ -46,9 +32,10 @@ public final class SearchBar: UISearchBar {
         self.setImage(UIImage(named: "ic_close_20_ios", in: .module, compatibleWith: nil), for: .clear, state: .normal)
         self.searchTextField.attributedText = .suit(.body_m_16, text: "")
         self.searchTextField.defaultTextAttributes[.font] = UIFont.suit(.body_m_16)
-        self.searchTextField.keyboardType = .asciiCapable
         self.searchTextField.autocorrectionType = .no
         self.searchTextField.autocapitalizationType = .none
+        self.searchTextField.returnKeyType = .done
+        self.searchTextField.placeholder = "닉네임을 입력해주세요."
     }
 
     private func updatePlaceholder() {

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/BaseUIViewController+Navigation.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/BaseUIViewController+Navigation.swift
@@ -17,6 +17,7 @@ public extension BaseUIViewController {
         case backTitle(String)
         case backTitleMenu(String)
         case backOnly
+        case backSearchBar(placeholder: String)
     }
 
     // MARK: - Setup
@@ -55,6 +56,18 @@ public extension BaseUIViewController {
                 imageName: "ic_arrow_left_black_24_ios",
                 action: #selector(backButtonTapped)
             )
+            navigationItem.rightBarButtonItem = nil
+            
+        case .backSearchBar(let placeholder):
+            navigationItem.leftBarButtonItem = makeBarButton(
+                imageName: "ic_arrow_left_b_24_ios",
+                action: #selector(backButtonTapped)
+            )
+            
+            let searchBar = SearchBar()
+            searchBar.placeholder = placeholder
+            
+            navigationItem.titleView = searchBar
             navigationItem.rightBarButtonItem = nil
         }
     }

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/BaseUIViewController+Navigation.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/BaseUIViewController+Navigation.swift
@@ -17,7 +17,7 @@ public extension BaseUIViewController {
         case backTitle(String)
         case backTitleMenu(String)
         case backOnly
-        case backSearchBar(placeholder: String)
+        case backSearchBar
     }
 
     // MARK: - Setup
@@ -58,16 +58,13 @@ public extension BaseUIViewController {
             )
             navigationItem.rightBarButtonItem = nil
             
-        case .backSearchBar(let placeholder):
+        case .backSearchBar:
             navigationItem.leftBarButtonItem = makeBarButton(
                 imageName: "ic_arrow_left_b_24_ios",
                 action: #selector(backButtonTapped)
             )
             
-            let searchBar = SearchBar()
-            searchBar.placeholder = placeholder
-            
-            navigationItem.titleView = searchBar
+            navigationItem.titleView = SearchBar()
             navigationItem.rightBarButtonItem = nil
         }
     }

--- a/HilingualPresentation/Sources/Presentation/Common/Factory/ViewControllerFactory.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Factory/ViewControllerFactory.swift
@@ -22,4 +22,5 @@ public protocol ViewControllerFactory {
         selectedDate: Date
     ) -> DiaryWritingViewController
     func makeFollowListViewController() -> FollowListViewController
+    func makeFeedSearchViewController() -> FeedSearchViewController
 }

--- a/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchEmptyView.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchEmptyView.swift
@@ -1,0 +1,72 @@
+//
+//  FeedSearchEmptyView.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 8/20/25.
+//
+
+import UIKit
+
+final class FeedSearchEmptyView: BaseUIView {
+    
+    // MARK: - Properties
+    
+    private let emptyLabel: UILabel = {
+        let label = UILabel()
+        label.text = "검색 결과가 없습니다."
+        label.font = .suit(.head_m_18)
+        label.textColor = .gray500
+        label.textAlignment = .center
+        return label
+    }()
+
+    private let emptyImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage(named: "img_search_ios", in: .module, compatibleWith: nil)
+        return imageView
+    }()
+
+    private let emptyStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 8
+        stack.alignment = .center
+        return stack
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup Methods
+    
+    override func setUI() {
+        addSubview(emptyStack)
+        emptyStack.addArrangedSubviews(
+            emptyImageView,
+            emptyLabel
+        )
+    }
+    
+    override func setLayout() {
+        emptyStack.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        emptyImageView.snp.makeConstraints {
+            $0.width.equalTo(210)
+            $0.height.equalTo(140)
+        }
+    }
+}
+

--- a/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchView.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchView.swift
@@ -1,0 +1,47 @@
+//
+//  FeedSearchView.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 8/20/25.
+//
+
+import UIKit
+
+final class FeedSearchView: BaseUIView {
+    
+    // MARK: - Properties
+    
+    let tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .plain)
+        table.separatorStyle = .none
+        table.backgroundColor = .white
+        table.sectionHeaderHeight = UITableView.automaticDimension
+        table.register(FollowListCell.self, forCellReuseIdentifier: FollowListCell.identifier)
+        return table
+    }()
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup Methods
+    
+    override func setUI() {
+        addSubviews(tableView)
+    }
+    
+    override func setLayout() {
+        tableView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewController.swift
@@ -13,7 +13,7 @@ public final class FeedSearchViewController: BaseUIViewController<FeedSearchView
     // MARK: - Properties
     
     private let searchBar = SearchBar()
-    private var userList: [FeedSearchUser] = []
+    private var userList: [FeedSearchUserModel] = []
     private let searchTrigger = PassthroughSubject<String, Never>()
     
     // MARK: - UI Components

--- a/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewController.swift
@@ -10,10 +10,19 @@ import Combine
 
 public final class FeedSearchViewController: BaseUIViewController<FeedSearchViewModel> {
     
+    // MARK: - Properties
+    
+    private let searchBar = SearchBar()
+    private var userList: [FeedSearchUser] = []
+    private let searchTrigger = PassthroughSubject<String, Never>()
+    
     // MARK: - UI Components
     
-    private let feedSearchView = FeedSearchView() // 테이블 뷰
+    private let feedSearchView = FeedSearchView()
     private let feedSearchEmptyView = FeedSearchEmptyView()
+    private var tableView: UITableView {
+        return feedSearchView.tableView
+    }
     
     // MARK: - Life Cycle
     
@@ -22,28 +31,153 @@ public final class FeedSearchViewController: BaseUIViewController<FeedSearchView
         
         setUI()
         setLayout()
+        setDelegate()
+        bind(viewModel: FeedSearchViewModel())
+    }
+    
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        searchBar.becomeFirstResponder()
     }
     
     // MARK: - Setup Methods
     
     public override func setUI() {
-        view.addSubview(feedSearchEmptyView)
+        view.addSubviews(feedSearchView, feedSearchEmptyView)
+        
+        feedSearchView.isHidden = true
+        feedSearchEmptyView.isHidden = true
+        
+        navigationItem.titleView = searchBar
+        searchBar.delegate = self
     }
     
     public override func setLayout() {
+        feedSearchView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
         feedSearchEmptyView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(242)
             $0.centerX.equalToSuperview()
         }
     }
     
+    public override func setDelegate() {
+        feedSearchView.tableView.dataSource = self
+        feedSearchView.tableView.delegate = self
+        searchBar.delegate = self
+    }
+    
+    // MARK: - Bind
+    
+    public override func bind(viewModel: FeedSearchViewModel) {
+        let output = viewModel.transform()
+
+        output.searchState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                self?.updateUI(for: state)
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Private Methods
+    
+    private func updateUI(for state: SearchState) {
+        switch state {
+        case .enter:
+            feedSearchView.isHidden = true
+            feedSearchEmptyView.isHidden = true
+        case .searchResult(let users):
+            self.userList = users
+            feedSearchView.isHidden = false
+            feedSearchEmptyView.isHidden = true
+            feedSearchView.tableView.reloadData()
+        case .empty:
+            self.userList = []
+            feedSearchView.isHidden = true
+            feedSearchEmptyView.isHidden = false
+            feedSearchView.tableView.reloadData()
+        }
+    }
+    
     // MARK: - Navigation
     
     public override func navigationType() -> NavigationType? {
-        return .backSearchBar(placeholder: "닉네임을 입력해주세요.")
+        return .backSearchBar
     }
     
     @objc public override func backButtonTapped() {
         navigationController?.popViewController(animated: true)
+        
+        searchBar.text = ""
+        userList = []
+        feedSearchView.isHidden = true
+        feedSearchEmptyView.isHidden = true
+        feedSearchView.tableView.reloadData()
+        
+        viewModel?.input.searchTrigger.send("")
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension FeedSearchViewController: UITableViewDataSource {
+    
+    public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return userList.count
+    }
+    
+    public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: FollowListCell.identifier, for: indexPath) as? FollowListCell else {
+            return UITableViewCell()
+        }
+        let user = userList[indexPath.row]
+        cell.delegate = self
+        cell.configure(with: user)
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension FeedSearchViewController: UITableViewDelegate {
+    
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        _ = userList[indexPath.row]
+    }
+    
+    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 58
+    }
+}
+
+// MARK: - UISearchBarDelegate
+
+extension FeedSearchViewController: UISearchBarDelegate {
+    public func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        guard let query = searchBar.text else { return }
+        searchBar.resignFirstResponder()
+        
+        viewModel?.input.searchTrigger.send(query)
+    }
+}
+
+// MARK: - FollowListCellDelegate
+
+extension FeedSearchViewController: FollowListCellDelegate {
+    
+    @MainActor
+    func followButtonTapped(cell: FollowListCell) {
+        guard let indexPath = tableView.indexPath(for: cell) else { return }
+        var user = userList[indexPath.row]
+        
+        user.isFollowing.toggle()
+        userList[indexPath.row] = user
+        
+        cell.configure(with: user)
+        
+        viewModel?.input.followButtonTapped.send(user.userId)
     }
 }

--- a/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewController.swift
@@ -1,0 +1,49 @@
+//
+//  FeedSearchViewController.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 8/20/25.
+//
+
+import UIKit
+import Combine
+
+public final class FeedSearchViewController: BaseUIViewController<FeedSearchViewModel> {
+    
+    // MARK: - UI Components
+    
+    private let feedSearchView = FeedSearchView() // 테이블 뷰
+    private let feedSearchEmptyView = FeedSearchEmptyView()
+    
+    // MARK: - Life Cycle
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setUI()
+        setLayout()
+    }
+    
+    // MARK: - Setup Methods
+    
+    public override func setUI() {
+        view.addSubview(feedSearchEmptyView)
+    }
+    
+    public override func setLayout() {
+        feedSearchEmptyView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(242)
+            $0.centerX.equalToSuperview()
+        }
+    }
+    
+    // MARK: - Navigation
+    
+    public override func navigationType() -> NavigationType? {
+        return .backSearchBar(placeholder: "닉네임을 입력해주세요.")
+    }
+    
+    @objc public override func backButtonTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  FeedSearchViewModel.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 8/20/25.
+//
+
+import Foundation
+import Combine
+
+import HilingualDomain
+
+public final class FeedSearchViewModel: BaseViewModel {
+    
+    public override init() { }
+    
+    // MARK: - Input / Output
+    
+    public struct Input {
+
+    }
+    
+    public struct Output {
+
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewModel.swift
@@ -10,17 +10,26 @@ import Combine
 
 import HilingualDomain
 
-public struct FeedSearchUser {
+public struct FeedSearchUserModel: UserDisplayable {
     public let userId: Int
     public let profileImg: String
     public let nickname: String
     public var isFollowing: Bool
     public var isFollowed: Bool
+    public var buttonState: FollowButtonState {
+        if isFollowing && isFollowed {
+            return .mutualFollow
+        } else if isFollowing {
+            return .following
+        } else {
+            return .follow
+        }
+    }
 }
 
 public enum SearchState {
     case enter // 처음 진입 시
-    case searchResult([FeedSearchUser]) // 검색 결과가 있으면
+    case searchResult([FeedSearchUserModel]) // 검색 결과가 있으면
     case empty // 검색 결과가 없으면
 }
 
@@ -53,7 +62,6 @@ public final class FeedSearchViewModel: BaseViewModel {
     private func setBinding() {
         input.followButtonTapped
             .sink { userId in
-                print("Follow 버튼 탭 userId:", userId)
             }
             .store(in: &cancellables)
     }
@@ -65,11 +73,11 @@ public final class FeedSearchViewModel: BaseViewModel {
             .map { query -> SearchState in
                 guard !query.isEmpty else { return .enter }
 
-                let mockData: [FeedSearchUser] = [
-                    FeedSearchUser(userId: 1, profileImg: "https://example.com/image1.jpg", nickname: "하링이", isFollowing: false, isFollowed: true),
-                    FeedSearchUser(userId: 2, profileImg: "https://example.com/image2.jpg", nickname: "하이링구얼", isFollowing: true, isFollowed: true),
-                    FeedSearchUser(userId: 3, profileImg: "https://example.com/image3.jpg", nickname: "하이링궐", isFollowing: false, isFollowed: false),
-                    FeedSearchUser(userId: 4, profileImg: "https://example.com/image4.jpg", nickname: "하품그만해", isFollowing: true, isFollowed: false)
+                let mockData: [FeedSearchUserModel] = [
+                    FeedSearchUserModel(userId: 1, profileImg: "https://example.com/image1.jpg", nickname: "하링이", isFollowing: false, isFollowed: true),
+                    FeedSearchUserModel(userId: 2, profileImg: "https://example.com/image2.jpg", nickname: "하이링구얼", isFollowing: true, isFollowed: true),
+                    FeedSearchUserModel(userId: 3, profileImg: "https://example.com/image3.jpg", nickname: "하이링궐", isFollowing: false, isFollowed: false),
+                    FeedSearchUserModel(userId: 4, profileImg: "https://example.com/image4.jpg", nickname: "하품그만해", isFollowing: true, isFollowed: false)
                 ]
 
                 let filtered = mockData.filter { $0.nickname.contains(query) }

--- a/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchViewModel.swift
@@ -10,17 +10,73 @@ import Combine
 
 import HilingualDomain
 
+public struct FeedSearchUser {
+    public let userId: Int
+    public let profileImg: String
+    public let nickname: String
+    public var isFollowing: Bool
+    public var isFollowed: Bool
+}
+
+public enum SearchState {
+    case enter // 처음 진입 시
+    case searchResult([FeedSearchUser]) // 검색 결과가 있으면
+    case empty // 검색 결과가 없으면
+}
+
 public final class FeedSearchViewModel: BaseViewModel {
-    
-    public override init() { }
     
     // MARK: - Input / Output
     
     public struct Input {
-
+        let searchTrigger: PassthroughSubject<String, Never>
+        let followButtonTapped: PassthroughSubject<Int, Never> = .init()
     }
     
     public struct Output {
+        let searchState: AnyPublisher<SearchState, Never>
+    }
+    
+    // MARK: - Properties
+    
+    public var input = Input(searchTrigger: .init())
+    
+    // MARK: - Init
+    
+    public override init() {
+        super.init()
+        setBinding()
+    }
+    
+    // MARK: - Bindings
+    
+    private func setBinding() {
+        input.followButtonTapped
+            .sink { userId in
+                print("Follow 버튼 탭 userId:", userId)
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Transform
+    
+    public func transform() -> Output {
+        let searchStatePublisher = input.searchTrigger
+            .map { query -> SearchState in
+                guard !query.isEmpty else { return .enter }
 
+                let mockData: [FeedSearchUser] = [
+                    FeedSearchUser(userId: 1, profileImg: "https://example.com/image1.jpg", nickname: "하링이", isFollowing: false, isFollowed: true),
+                    FeedSearchUser(userId: 2, profileImg: "https://example.com/image2.jpg", nickname: "하이링구얼", isFollowing: true, isFollowed: true),
+                    FeedSearchUser(userId: 3, profileImg: "https://example.com/image3.jpg", nickname: "하이링궐", isFollowing: false, isFollowed: false),
+                    FeedSearchUser(userId: 4, profileImg: "https://example.com/image4.jpg", nickname: "하품그만해", isFollowing: true, isFollowed: false)
+                ]
+
+                let filtered = mockData.filter { $0.nickname.contains(query) }
+                return filtered.isEmpty ? .empty : .searchResult(filtered)
+            }
+            .eraseToAnyPublisher()
+
+        return Output(searchState: searchStatePublisher)
     }
 }

--- a/HilingualPresentation/Sources/Presentation/FollowList/FollowListViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/FollowList/FollowListViewModel.swift
@@ -15,11 +15,11 @@ public enum FollowListType {
     case following
 }
 
-public struct FollowUserModel {
+public struct FollowUserModel: UserDisplayable {
     let userId: Int
     let profileImg: String
     let nickname: String
-    let buttonState: FollowButton.FollowButtonState
+    let buttonState: FollowButtonState
 }
 
 public struct FollowListModel {
@@ -139,7 +139,7 @@ public final class FollowListViewModel: BaseViewModel {
     
     // Domain 모델을 UI 모델로 매핑
     private func mapToUserModel(from domainFollower: Follower, type: FollowListType) -> FollowUserModel {
-        let buttonState: FollowButton.FollowButtonState
+        let buttonState: FollowButtonState
         switch type {
         case .follower:
             buttonState = domainFollower.isFollowing ? .following : .mutualFollow

--- a/HilingualPresentation/Sources/Presentation/FollowList/FollowListViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/FollowList/FollowListViewModel.swift
@@ -26,6 +26,7 @@ public struct FollowListModel {
     var type: FollowListType
     var users: [FollowUserModel]
 }
+
 public final class FollowListViewModel: BaseViewModel {
     
     // MARK: - Published Properties

--- a/HilingualPresentation/Sources/Presentation/FollowList/TableView/FollowListCell.swift
+++ b/HilingualPresentation/Sources/Presentation/FollowList/TableView/FollowListCell.swift
@@ -96,6 +96,17 @@ final class FollowListCell: UITableViewCell {
         }
     }
     
+    // MARK: - Configure
+    
+    func configure(with user: FeedSearchUser) {
+        // profileImg.setImage(with: URL(string: user.profileImg))
+        nickname.text = user.nickname
+        button.configure(state: user.isFollowing ? .following : .follow, size: .short)
+        
+        button.removeTarget(nil, action: nil, for: .allEvents)
+        button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+    }
+    
     // MARK: - Action
     
     @objc private func buttonTapped() {

--- a/HilingualPresentation/Sources/Presentation/FollowList/TableView/FollowListCell.swift
+++ b/HilingualPresentation/Sources/Presentation/FollowList/TableView/FollowListCell.swift
@@ -98,10 +98,10 @@ final class FollowListCell: UITableViewCell {
     
     // MARK: - Configure
     
-    func configure(with user: FeedSearchUser) {
+    func configure(with user: UserDisplayable) {
         // profileImg.setImage(with: URL(string: user.profileImg))
         nickname.text = user.nickname
-        button.configure(state: user.isFollowing ? .following : .follow, size: .short)
+        button.configure(state: user.buttonState, size: .short)
         
         button.removeTarget(nil, action: nil, for: .allEvents)
         button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [x] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #200 

---

## 📎 Work Description 
- 피드 내 검색기능을 구현했습니다.
- FeedSearchView에서는 FollowListView를 구현할 때 사용했던 FollowListCell을 재사용하여 구현하였습니다.
- Common > Protocol > UserDisplayable를 구현하여 configure 함수에서 해당 프로토콜을 채택한 구조체의 값을 할당시켜 공통으로 사용할 수 있도록 수정하였습니다.
- SearchBar가 포함된 네비게이션 바가 필요해서, .backSearchBar를 enum에 추가해 구현했습니다.

---

## 📷 Screenshots  

| 기능/화면 | 피드 |
|:---------:|:---------:|
| 검색 | <img src="https://github.com/user-attachments/assets/aa9efb72-9a83-4960-a88d-978b09eba810" width="250"> | 
---

## 💬 To Reviewers  
- 오늘까지는 뷰 작업 마무리라서, Mock Service로 값 넣어주는 로직은 이후에 따로 이슈파서 작업하려고 현재는 뷰모델에서 더미를 넣어주었습니다. 참고 부탁드립니다 :)
- 200번 이슈 너무 좋았네요 ㅎ ㅎ 300번도 나의 것