### PR TITLE
[refactor] FollowButton width 제약 제거

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/FollowButton.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/FollowButton.swift
@@ -15,21 +15,12 @@ public enum FollowButtonState {
     case unblock        // 차단 해제
 }
 
-enum ButtonSize {
-    case short
-    case long
-}
-
 final class FollowButton: UIButton {
     
     // MARK: - Properties
     
     private var currentState: FollowButtonState = .follow {
         didSet { setStyle() }
-    }
-    
-    private var currentSize: ButtonSize = .short {
-        didSet { updateSize() }
     }
     
     override var isHighlighted: Bool {
@@ -44,7 +35,7 @@ final class FollowButton: UIButton {
         super.init(frame: frame)
         
         setStyle()
-        updateSize()
+        setLayout()
     }
     
     required init?(coder: NSCoder) {
@@ -89,17 +80,15 @@ final class FollowButton: UIButton {
         }
     }
     
-    private func updateSize() {
-        snp.remakeConstraints {
+    private func setLayout() {
+        snp.makeConstraints {
             $0.height.equalTo(33)
-            $0.width.equalTo(currentSize == .short ? 80 : 343)
         }
     }
     
-    // MARK: - Public Methods
+    // MARK: - Configure
     
-    func configure(state: FollowButtonState, size: ButtonSize) {
+    func configure(state: FollowButtonState) {
         self.currentState = state
-        self.currentSize = size
     }
 }

--- a/HilingualPresentation/Sources/Presentation/FollowList/TableView/FollowListCell.swift
+++ b/HilingualPresentation/Sources/Presentation/FollowList/TableView/FollowListCell.swift
@@ -78,7 +78,7 @@ final class FollowListCell: UITableViewCell {
     
     private func setStyle() {
         backgroundColor = .white
-        button.configure(state: .following, size: .short)
+        button.configure(state: .following)
     }
     
     private func setUI() {
@@ -94,6 +94,10 @@ final class FollowListCell: UITableViewCell {
             $0.horizontalEdges.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
         }
+        
+        button.snp.makeConstraints {
+            $0.width.equalTo(80)
+        }
     }
     
     // MARK: - Configure
@@ -101,7 +105,7 @@ final class FollowListCell: UITableViewCell {
     func configure(with user: UserDisplayable) {
         // profileImg.setImage(with: URL(string: user.profileImg))
         nickname.text = user.nickname
-        button.configure(state: user.buttonState, size: .short)
+        button.configure(state: user.buttonState)
         
         button.removeTarget(nil, action: nil, for: .allEvents)
         button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)

--- a/HilingualPresentation/Sources/Presentation/FollowList/ViewController/FollowerListViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FollowList/ViewController/FollowerListViewController.swift
@@ -72,7 +72,7 @@ extension FollowerListViewController: UITableViewDataSource {
         
         if let user = viewModel?.followerList[indexPath.row] {
             cell.nickname.text = user.nickname
-            cell.button.configure(state: user.buttonState, size: .short)
+            cell.button.configure(state: user.buttonState)
         }
         
         cell.delegate = self

--- a/HilingualPresentation/Sources/Presentation/FollowList/ViewController/FollowingListViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FollowList/ViewController/FollowingListViewController.swift
@@ -72,7 +72,7 @@ extension FollowingListViewController: UITableViewDataSource {
         
         if let user = viewModel?.followingList[indexPath.row] {
             cell.nickname.text = user.nickname
-            cell.button.configure(state: user.buttonState, size: .short)
+            cell.button.configure(state: user.buttonState)
         }
         
         cell.delegate = self


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [x] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #226 

---

## 📎 Work Description 
- FollowButton width 제약 제거하였습니다.
- 아래와 같이 사용 및 변경해주시면 됩니다.
```
let followButton = FollowButton()
view.addSubview(followButton)

followButton.configure(state: .follow)

followButton.snp.makeConstraints {
    // $0.horizontal.equalToSuperview().inset(16)와 같이 부모뷰에서 horizontal을 주거나
    // $0.width.equalTo(80)와 같이 직접 width를 주어서 사용할 수 있습니다.
}
```

---

## 📷 Screenshots  

| 기능/화면 | width 노지정 | width 예스지정 |
|:---------:|:---------:|:-------------:|
| 버튼 | <img src="https://github.com/user-attachments/assets/d8e2ed63-7b36-4270-8c7a-82a764e2b107" width="250"> | <img src="https://github.com/user-attachments/assets/1c1c93b5-2dff-452d-9f57-0ce28c704241" width="250"> |


---

## 💬 To Reviewers  
- 이제 오비면접 준비하러 갈게엽 🫡
