### PR TITLE
[fix] CalendarView auto layout 제약 충돌 해결

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarContentView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarContentView.swift
@@ -39,6 +39,7 @@ final class CalendarContentView: UICollectionView {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumInteritemSpacing = 0
         flowLayout.minimumLineSpacing = 14
+        flowLayout.estimatedItemSize = .zero
         super.init(frame: .zero, collectionViewLayout: flowLayout)
 
         isScrollEnabled = false
@@ -57,8 +58,10 @@ final class CalendarContentView: UICollectionView {
     func reload(for date: Date) {
         currentDate = date
         generateDays()
-        reloadData()
-        invalidateIntrinsicContentSize()
+        DispatchQueue.main.async {
+            self.reloadData()
+            self.invalidateIntrinsicContentSize()
+        }
     }
 
     func setSelectedDate(_ date: Date) {
@@ -108,6 +111,7 @@ final class CalendarContentView: UICollectionView {
 
     private func updateItemSize() {
         let width = bounds.width / 7
+        guard width > 0 else { return }
         (collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize = CGSize(width: width, height: 34)
     }
 
@@ -131,13 +135,16 @@ final class CalendarContentView: UICollectionView {
 
 extension CalendarContentView: UICollectionViewDataSource, UICollectionViewDelegate {
 
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int)
+    -> Int {
         return days.count
     }
 
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CustomCalendarCell", for: indexPath) as! CustomCalendarCell
-
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath)
+    -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: "CustomCalendarCell", for: indexPath
+        ) as! CustomCalendarCell
         let date = days[indexPath.item]
         let day = calendar.component(.day, from: date)
         let isToday = calendar.isDateInToday(date)

--- a/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarHeaderView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarHeaderView.swift
@@ -166,4 +166,8 @@ final class CalendarHeaderView: UIView {
         formatter.dateFormat = "yyyy년 M월"
         return formatter.string(from: date)
     }
+    
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: UIView.noIntrinsicMetric, height: 28)
+    }
 }

--- a/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarHeaderView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarHeaderView.swift
@@ -61,8 +61,17 @@ final class CalendarHeaderView: UIView {
     private let buttonStack: UIStackView = {
         let stack = UIStackView()
         stack.axis = .horizontal
-        stack.spacing = 8
+        stack.spacing = 12
         stack.alignment = .center
+        return stack
+    }()
+    
+    private let datePickerStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 4
+        stack.alignment = .center
+        stack.isUserInteractionEnabled = false
         return stack
     }()
 
@@ -86,34 +95,27 @@ final class CalendarHeaderView: UIView {
 
         backgroundColor = .clear
 
-        let stack = UIStackView(arrangedSubviews: [textLabel, iconView])
-        stack.axis = .horizontal
-        stack.spacing = 4
-        stack.alignment = .center
-        stack.isUserInteractionEnabled = false
+        monthButton.addSubview(datePickerStack)
 
-        monthButton.addSubview(stack)
-        stack.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-
-        buttonStack.addArrangedSubview(previousButton)
-        buttonStack.addArrangedSubview(nextButton)
+        buttonStack.addArrangedSubviews(previousButton, nextButton)
+        datePickerStack.addArrangedSubviews(textLabel, iconView)
 
         addSubviews(monthButton, buttonStack)
     }
 
     private func setupLayout() {
         monthButton.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide).inset(16)
+            $0.top.equalToSuperview()
             $0.leading.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().inset(12)
+        }
+
+        datePickerStack.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
 
         buttonStack.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide).inset(16)
+            $0.centerY.equalTo(monthButton)
             $0.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().inset(12)
         }
     }
 

--- a/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarView.swift
@@ -84,7 +84,6 @@ final class CalendarView: UIView {
         headerView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(16)
             $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(28)
         }
         
         weekStackView.snp.makeConstraints {
@@ -94,7 +93,7 @@ final class CalendarView: UIView {
 
         scrollView.snp.makeConstraints {
             $0.top.equalTo(weekStackView.snp.bottom).offset(8)
-            $0.leading.trailing.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
             scrollViewHeightConstraint = $0.height.equalTo(0).constraint
         }
     }
@@ -227,7 +226,8 @@ extension CalendarView: UIScrollViewDelegate {
         configureCalendars(for: currentDate)
         headerView.setCurrentDate(currentDate)
 
-        let firstDayOfMonth = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: currentDate))!
+        let firstDayOfMonth = Calendar.current.date(
+            from: Calendar.current.dateComponents([.year, .month], from: currentDate))!
         calendarViews[1].setSelectedDate(firstDayOfMonth)
         onDateSelected?(firstDayOfMonth)
 
@@ -236,5 +236,4 @@ extension CalendarView: UIScrollViewDelegate {
 
         onMonthChanged?(currentDate)
     }
-
 }

--- a/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarView.swift
@@ -82,13 +82,14 @@ final class CalendarView: UIView {
 
     private func setupLayout() {
         headerView.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
+            $0.top.equalToSuperview().offset(16)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(28)
         }
-
+        
         weekStackView.snp.makeConstraints {
-            $0.top.equalTo(headerView.snp.bottom)
+            $0.top.equalTo(headerView.snp.bottom).offset(12)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(20)
         }
 
         scrollView.snp.makeConstraints {
@@ -194,6 +195,16 @@ final class CalendarView: UIView {
         layoutIfNeeded()
         let contentHeight = calendarViews[1].intrinsicContentSize.height
         scrollViewHeightConstraint?.update(offset: contentHeight)
+        invalidateIntrinsicContentSize()
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        let headerHeight: CGFloat = 28
+        let weekHeight: CGFloat = 20
+        let spacing: CGFloat = 16 + 12 + 8
+        let contentHeight = calendarViews[1].intrinsicContentSize.height
+        return CGSize(width: UIView.noIntrinsicMetric,
+                      height: headerHeight + weekHeight + spacing + contentHeight)
     }
 }
 


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #262

---

## 📎 Work Description 
**CalendarView 및 관련 뷰들의 레이아웃 문제를 해결했습니다!!**
- CalendarView에서 AutoLayout 충돌 발생하던 제약 조건 제거 및 정리
- CalendarContentView의 itemSize가 0으로 계산되던 문제 수정
- intrinsicContentSize를 기반으로 CalendarView의 높이가 동적으로 계산되도록 개선

---

## 📷 Screenshots  

---

## 💬 To Reviewers  
- 와..... 캘린더 관련 코드들 나중에 리펙해야 할 것 같아요... 앱잼 때의 나.. 대체 왜 이렇게 코드를 짠걸까 .. ㅋㅋ