### PR TITLE
[network] 소셜로그인 API 연결

### DIFF
--- a/HilingualData/Sources/HilingualData/Mapper/LoginResponseDTO+Mapper.swift
+++ b/HilingualData/Sources/HilingualData/Mapper/LoginResponseDTO+Mapper.swift
@@ -15,7 +15,7 @@ extension LoginResponseDTO {
         return LoginResponseEntity(
             accessToken: self.accessToken,
             refreshToken: self.refreshToken,
-            isProfileCompleted: self.isProfileCompleted
+            isProfileCompleted: self.registerStatus
         )
     }
 }

--- a/HilingualNetwork/Sources/HilingualNetwork/API/AuthAPI.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/API/AuthAPI.swift
@@ -8,7 +8,7 @@
 import Moya
 
 public enum AuthAPI {
-    case socialLogin(provider: String, providerToken: String)
+    case socialLogin(body: AuthLoginRequestDTO, providerToken: String)
     case refreshToken(refreshToken: String)
 }
 
@@ -28,8 +28,8 @@ extension AuthAPI: NoAuthorizeTargetType {
 
     public var task: Task {
         switch self {
-        case let .socialLogin(provider, _):
-            return .requestJSONEncodable(["provider": provider])
+        case let .socialLogin(body, _):
+            return .requestJSONEncodable(body)
         case .refreshToken:
             return .requestPlain
         }
@@ -37,10 +37,10 @@ extension AuthAPI: NoAuthorizeTargetType {
 
     public var headers: [String: String]? {
         switch self {
-        case let .socialLogin(_, token):
+        case let .socialLogin(_, providerToken):
             return [
                 "Content-Type": "application/json",
-                "Provider-Token": token
+                "Provider-Token": providerToken
             ]
         case let .refreshToken(refreshToken):
             return [

--- a/HilingualNetwork/Sources/HilingualNetwork/API/AuthAPI.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/API/AuthAPI.swift
@@ -18,7 +18,7 @@ extension AuthAPI: NoAuthorizeTargetType {
         case .socialLogin:
             return "/auth/login"
         case .refreshToken:
-            return "/auth/reissue"
+            return "/users/reissue"
         }
     }
 

--- a/HilingualNetwork/Sources/HilingualNetwork/API/OnBoardingAPI.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/API/OnBoardingAPI.swift
@@ -22,7 +22,7 @@ extension OnBoardingAPI: TargetType {
     public var path: String {
         switch self {
         case .checkNickname, .setProfile:
-            return "/users/profile"
+            return "/users/profile/check"
         }
     }
 

--- a/HilingualNetwork/Sources/HilingualNetwork/DTO/LoginResponseDTO.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/DTO/LoginResponseDTO.swift
@@ -10,5 +10,33 @@ import Foundation
 public struct LoginResponseDTO: Decodable {
     public let accessToken: String
     public let refreshToken: String
-    public let isProfileCompleted: Bool
+    public let registerStatus: Bool
+}
+
+public struct AuthLoginRequestDTO: Encodable {
+    public let provider: String
+    public let role: String
+    public let deviceName: String
+    public let deviceType: String
+    public let osType: String
+    public let osVersion: String
+    public let appVersion: String
+
+    public init(
+        provider: String,
+        role: String,
+        deviceName: String,
+        deviceType: String,
+        osType: String,
+        osVersion: String,
+        appVersion: String
+    ) {
+        self.provider = provider
+        self.role = role
+        self.deviceName = deviceName
+        self.deviceType = deviceType
+        self.osType = osType
+        self.osVersion = osVersion
+        self.appVersion = appVersion
+    }
 }

--- a/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultAuthService.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultAuthService.swift
@@ -7,54 +7,72 @@
 
 import Foundation
 import Combine
+import UIKit
 
 public protocol AuthService {
     func loginWithApple(token: String) -> AnyPublisher<LoginResponseDTO, Error>
     func refreshToken(token: String) -> AnyPublisher<TokenRefreshResponseDTO, Error>
 }
 
-public final class DefaultAuthService: BaseService<AuthAPI>, AuthService {    
+public final class DefaultAuthService: BaseService<AuthAPI>, AuthService {
 
     public func loginWithApple(token: String) -> AnyPublisher<LoginResponseDTO, Error> {
-            #if DEBUG
-            let dummyResponse = LoginResponseDTO(
-                accessToken: "debug_access_token",
-                refreshToken: "debug_refresh_token",
-                isProfileCompleted: false
-            )
-            return Just(dummyResponse)
-                .setFailureType(to: Error.self)
-                .eraseToAnyPublisher()
-            #else
-            let target = AuthAPI.socialLogin(provider: "APPLE", providerToken: token)
-            return request(target, as: BaseAPIResponse<LoginResponseDTO>.self)
-                .tryMap { response in
-                    return response.data
-                }
-                .mapError { $0 as Error }
-                .eraseToAnyPublisher()
-            #endif
-        }
+//        #if DEBUG
+//        let dummyResponse = LoginResponseDTO(
+//            accessToken: "debug_access_token",
+//            refreshToken: "debug_refresh_token",
+//            isProfileCompleted: false
+//        )
+//        return Just(dummyResponse)
+//            .setFailureType(to: Error.self)
+//            .eraseToAnyPublisher()
+//        #else
+        let body = AuthLoginRequestDTO(
+            provider: "APPLE",
+            role: "USER",
+            deviceName: UIDevice.current.name,
+            deviceType: {
+                #if targetEnvironment(macCatalyst)
+                return "DESKTOP"
+                #elseif os(iOS)
+                return UIDevice.current.userInterfaceIdiom == .pad ? "TABLET" : "PHONE"
+                #else
+                return "UNKNOWN"
+                #endif
+            }(),
+            osType: UIDevice.current.systemName,
+            osVersion: UIDevice.current.systemVersion,
+            appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        )
+
+        let target = AuthAPI.socialLogin(body: body, providerToken: token)
+
+        return request(target, as: BaseAPIResponse<LoginResponseDTO>.self)
+            .tryMap { response in
+                return response.data
+            }
+            .mapError { $0 as Error }
+            .eraseToAnyPublisher()
+//        #endif
+    }
 
     public func refreshToken(token: String) -> AnyPublisher<TokenRefreshResponseDTO, Error> {
-           #if DEBUG
-           let dummyResponse = TokenRefreshResponseDTO(
-               accessToken: "debug_refreshed_access_token",
-               refreshToken: "debug_refreshed_refresh_token"
-           )
-           return Just(dummyResponse)
-               .setFailureType(to: Error.self)
-               .eraseToAnyPublisher()
-           #else
-           let target = AuthAPI.refreshToken(refreshToken: token)
-           return request(target, as: BaseAPIResponse<TokenRefreshResponseDTO>.self)
-               .tryMap { response in
-                   return response.data
-               }
-               .mapError { $0 as Error }
-               .eraseToAnyPublisher()
-           #endif
-       }
+//        #if DEBUG
+//        let dummyResponse = TokenRefreshResponseDTO(
+//            accessToken: "debug_refreshed_access_token",
+//            refreshToken: "debug_refreshed_refresh_token"
+//        )
+//        return Just(dummyResponse)
+//            .setFailureType(to: Error.self)
+//            .eraseToAnyPublisher()
+//        #else
+        let target = AuthAPI.refreshToken(refreshToken: token)
+        return request(target, as: BaseAPIResponse<TokenRefreshResponseDTO>.self)
+            .tryMap { response in
+                return response.data
+            }
+            .mapError { $0 as Error }
+            .eraseToAnyPublisher()
+//        #endif
+    }
 }
-
-

--- a/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultOnBoardingService.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultOnBoardingService.swift
@@ -34,17 +34,9 @@ public final class DefaultOnBoardingService: BaseService<OnBoardingAPI>, OnBoard
     }
 
     public func checkNicknameDuplication(nickname: String) -> AnyPublisher<Bool, Error> {
-        #if DEBUG
-        // 디버그 모드에서는 닉네임이 "샤갈"일 경우 false 반환하도록 테스트 대비
-        let isAvailable = (nickname.lowercased() != "샤갈")
-        return Just(isAvailable)
-            .setFailureType(to: Error.self)
-            .eraseToAnyPublisher()
-        #else
         return request(.checkNickname(nickname: nickname), as: OnBoardingResponseDTO.self)
             .map { $0.data.isAvailable }
             .mapError { $0 as Error }
             .eraseToAnyPublisher()
-        #endif
     }
 }

--- a/HilingualPresentation/Sources/Presentation/Splash/SplashViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/Splash/SplashViewModel.swift
@@ -93,8 +93,13 @@ public final class SplashViewModel: BaseViewModel {
                         refreshToken: response.refreshToken
                     )
 
+                    #if DEBUG
+                    let isProfileCompleted = true
+                    print("[SplashVM] ⚙️ DEBUG 모드라서 → isProfileCompleted 강제 true임 ㅋㅋ")
+                    #else
                     let isProfileCompleted = UserDefaults.standard.bool(forKey: "isProfileCompleted")
                     print("[SplashVM] 로컬 프로필 완료 여부: \(isProfileCompleted)")
+                    #endif
 
                     if isProfileCompleted {
                         print("[SplashVM] 홈 화면 이동")
@@ -107,4 +112,5 @@ public final class SplashViewModel: BaseViewModel {
             )
             .store(in: &cancellables)
     }
+
 }


### PR DESCRIPTION
변경된 provider을 위한 responseDTO, 를 추가했습니다

## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #264 

---

## 📎 Work Description 
- 변경된 소셜로그인 API를 연결했습니다
- 현재 저희 프로젝트에서는 UIKit 의존성을 Presentation 레이어에만 한정하도록 구조를 설계하고 있습니다.
하지만 이번 로그인 API 요청 구현에서, 불가피하게 Service 레이어에서 UIKit을 import하게 된 부분이 있습니다.
그 이유는 다음과 같습니다:
변경된 로그인 API 요구사항에 따라, 디바이스 이름, 기기 종류, OS 타입 및 버전 등의 정보를 요청 바디에 포함해야 했습니다.
이 값들은 모두 UIKit (정확히는 UIDevice)에서 제공되는 시스템 정보이기 때문에, 해당 값을 어디서 생성하고 주입해야 할지 책임을 명확히 나누기 어려웠습니다.
구조적으로 보면 이 책임은 Presentation 또는 UseCase 레이어에서 처리하는 것이 옳을 수 있지만,
로그인 시점에 단일 provider에 대한 요청만 필요한 상황에서 이를 위해 entity, useCase, repository 등의 구조를 모두 거치는 것은 과도한 파일 분리와 계층 확장으로 인한 비효율로 판단했습니다.
결과적으로, UIKit 의존을 Service에서 직접 갖도록 선택하게 되었고, 이는 구조적으로 완전히 만족스럽지는 않지만,
현재 프로젝트 규모와 흐름을 고려했을 때 실용적인 타협안이라고 판단해 위치했는데 리뷰하시는 분들 생각도 궁금합니다! 

- 인증코드는 한정된 자원인만큼 ㅋㅋ ㅠㅠ최후에 붙일예정입니다. 

지금 생각나는 대안은 
- 기존 방식 유지 
- core 모듈을 하나만들기
- app모듈에 위치 시켜서 service에 DI로 주입하기

---

## 📷 Screenshots  

| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| A 기능 | <img src="" width="250"> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |

---

## 💬 To Reviewers  
- 이슈이름 틀린거 죄송합니다,, 강제 헤커톤중이라 ㅎㅎ,,, ㅠㅠㅠ
