### PR TITLE
[refactor] 기능 QA 반영 

### DIFF
--- a/HilingualData/Sources/HilingualData/Repository/DefaultAuthRepository.swift
+++ b/HilingualData/Sources/HilingualData/Repository/DefaultAuthRepository.swift
@@ -49,11 +49,11 @@ public final class DefaultAuthRepository: AuthRepository {
     }
 
     public func logout() -> AnyPublisher<Void, Error> {
-        return Future<Void, Error> { [weak self] promise in
-            self?.tokenStore.clear()
-            promise(.success(()))
-        }
-        .eraseToAnyPublisher()
+        return authService.logout()
+            .handleEvents(receiveOutput: { [weak self] in
+                self?.tokenStore.clear()
+            })
+            .eraseToAnyPublisher()
     }
 
     public func withdraw() -> AnyPublisher<Void, Error> {

--- a/HilingualData/Sources/HilingualData/Repository/DefaultOnBoardingRepository.swift
+++ b/HilingualData/Sources/HilingualData/Repository/DefaultOnBoardingRepository.swift
@@ -18,8 +18,13 @@ public final class DefaultOnBoardingRepository: OnBoardingRepository {
         self.service = service
     }
     
-    public func isNicknameAvailable(_ nickname: String) -> AnyPublisher<Bool, any Error> {
+    public func isNicknameAvailable(_ nickname: String) -> AnyPublisher<(Bool, String?), Never> {
         service.checkNicknameDuplication(nickname: nickname)
+            .map { dto in
+                return (dto.data.isAvailable, dto.message)
+            }
+            .replaceError(with: (false, "중복 확인 중 오류가 발생했어요."))
+            .eraseToAnyPublisher()
     }
 
     public func registerProfile(profile: ProfileEntity) -> AnyPublisher<Void, Error> {

--- a/HilingualDomain/Sources/HilingualDomain/Interface/Repository/OnBoardingRepository.swift
+++ b/HilingualDomain/Sources/HilingualDomain/Interface/Repository/OnBoardingRepository.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 public protocol OnBoardingRepository {
-    func isNicknameAvailable(_ nickname: String) -> AnyPublisher<Bool, Error>
+    func isNicknameAvailable(_ nickname: String) -> AnyPublisher<(Bool, String?), Never>
     func registerProfile(profile: ProfileEntity) -> AnyPublisher<Void, Error>
 }
 

--- a/HilingualDomain/Sources/HilingualDomain/UseCase/OnBoardingUseCase.swift
+++ b/HilingualDomain/Sources/HilingualDomain/UseCase/OnBoardingUseCase.swift
@@ -10,7 +10,7 @@ import Combine
 
 public protocol OnBoardingUseCase {
     func validate(_ nickname: String) -> NicknameValidationResult
-    func checkDuplicate(_ nickname: String) -> AnyPublisher<Bool, Error>
+    func checkDuplicate(_ nickname: String) -> AnyPublisher<(Bool, String?), Never>
     func registerProfile(nickname: String, adAlarmAgree: Bool, fileKey: String?) -> AnyPublisher<Void, Error>
 }
 
@@ -34,7 +34,7 @@ public final class DefaultOnBoardingUseCase: OnBoardingUseCase {
         }
     }
 
-    public func checkDuplicate(_ nickname: String) -> AnyPublisher<Bool, Error> {
+    public func checkDuplicate(_ nickname: String) -> AnyPublisher<(Bool, String?), Never> {
         return onBoardingRepository.isNicknameAvailable(nickname)
     }
 

--- a/HilingualNetwork/Sources/HilingualNetwork/API/AuthAPI.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/API/AuthAPI.swift
@@ -11,6 +11,7 @@ public enum AuthAPI {
     case socialLogin(body: AuthLoginRequestDTO, providerToken: String)
     case refreshToken(refreshToken: String)
     case withdraw
+    case logout
 }
 
 extension AuthAPI: NoAuthorizeTargetType {
@@ -22,6 +23,8 @@ extension AuthAPI: NoAuthorizeTargetType {
             return "/users/reissue"
         case .withdraw:
             return "/auth/leave"
+        case .logout:
+            return "/auth/logout"
         }
     }
 
@@ -33,6 +36,8 @@ extension AuthAPI: NoAuthorizeTargetType {
             return .post
         case .withdraw:
             return .post
+        case .logout:
+            return .post
         }
     }
 
@@ -43,6 +48,8 @@ extension AuthAPI: NoAuthorizeTargetType {
         case .refreshToken:
             return .requestPlain
         case .withdraw:
+            return .requestPlain
+        case .logout:
             return .requestPlain
         }
     }
@@ -60,6 +67,11 @@ extension AuthAPI: NoAuthorizeTargetType {
                 "Authorization": "Bearer \(refreshToken)"
             ]
         case .withdraw:
+            return [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(UserDefaultHandler.accessToken)"
+            ]
+        case .logout:
             return [
                 "Content-Type": "application/json",
                 "Authorization": "Bearer \(UserDefaultHandler.accessToken)"

--- a/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultAuthService.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultAuthService.swift
@@ -13,33 +13,25 @@ public protocol AuthService {
     func loginWithApple(token: String) -> AnyPublisher<LoginResponseDTO, Error>
     func refreshToken(token: String) -> AnyPublisher<TokenRefreshResponseDTO, Error>
     func withdraw() -> AnyPublisher<Void, Error>
+    func logout() -> AnyPublisher<Void, Error>
 }
 
 public final class DefaultAuthService: BaseService<AuthAPI>, AuthService {
 
+    //TODO: - Uikit 의존성 제거하기
     public func loginWithApple(token: String) -> AnyPublisher<LoginResponseDTO, Error> {
-//        #if DEBUG
-//        let dummyResponse = LoginResponseDTO(
-//            accessToken: "debug_access_token",
-//            refreshToken: "debug_refresh_token",
-//            isProfileCompleted: false
-//        )
-//        return Just(dummyResponse)
-//            .setFailureType(to: Error.self)
-//            .eraseToAnyPublisher()
-//        #else
         let body = AuthLoginRequestDTO(
             provider: "APPLE",
             role: "USER",
             deviceName: UIDevice.current.name,
             deviceType: {
-                #if targetEnvironment(macCatalyst)
+#if targetEnvironment(macCatalyst)
                 return "DESKTOP"
-                #elseif os(iOS)
+#elseif os(iOS)
                 return UIDevice.current.userInterfaceIdiom == .pad ? "TABLET" : "PHONE"
-                #else
+#else
                 return "UNKNOWN"
-                #endif
+#endif
             }(),
             osType: UIDevice.current.systemName,
             osVersion: UIDevice.current.systemVersion,
@@ -54,19 +46,9 @@ public final class DefaultAuthService: BaseService<AuthAPI>, AuthService {
             }
             .mapError { $0 as Error }
             .eraseToAnyPublisher()
-//        #endif
     }
 
     public func refreshToken(token: String) -> AnyPublisher<TokenRefreshResponseDTO, Error> {
-//        #if DEBUG
-//        let dummyResponse = TokenRefreshResponseDTO(
-//            accessToken: "debug_refreshed_access_token",
-//            refreshToken: "debug_refreshed_refresh_token"
-//        )
-//        return Just(dummyResponse)
-//            .setFailureType(to: Error.self)
-//            .eraseToAnyPublisher()
-//        #else
         let target = AuthAPI.refreshToken(refreshToken: token)
         return request(target, as: BaseAPIResponse<TokenRefreshResponseDTO>.self)
             .tryMap { response in
@@ -74,10 +56,17 @@ public final class DefaultAuthService: BaseService<AuthAPI>, AuthService {
             }
             .mapError { $0 as Error }
             .eraseToAnyPublisher()
-//        #endif
     }
+
     public func withdraw() -> AnyPublisher<Void, Error> {
         return requestPlain(.withdraw)
+            .map { _ in }
+            .mapError { $0 as Error }
+            .eraseToAnyPublisher()
+    }
+
+    public func logout() -> AnyPublisher<Void, Error> {
+        return requestPlain(.logout)
             .map { _ in }
             .mapError { $0 as Error }
             .eraseToAnyPublisher()

--- a/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultOnBoardingService.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultOnBoardingService.swift
@@ -11,7 +11,7 @@ import Moya
 import Combine
 
 public protocol OnBoardingService {
-    func checkNicknameDuplication(nickname: String) -> AnyPublisher<Bool, Error>
+    func checkNicknameDuplication(nickname: String) -> AnyPublisher<OnBoardingResponseDTO, Error>
     func registerProfile(nickname: String, adAlarmAgree: Bool, fileKey: String?) -> AnyPublisher<Void, Error>
 }
 
@@ -30,9 +30,8 @@ public final class DefaultOnBoardingService: BaseService<OnBoardingAPI>, OnBoard
 //        #endif
     }
 
-    public func checkNicknameDuplication(nickname: String) -> AnyPublisher<Bool, Error> {
+    public func checkNicknameDuplication(nickname: String) -> AnyPublisher<OnBoardingResponseDTO, Error> {
         return request(.checkNickname(nickname: nickname), as: OnBoardingResponseDTO.self)
-            .map { $0.data.isAvailable }
             .mapError { $0 as Error }
             .eraseToAnyPublisher()
     }

--- a/HilingualPresentation/Sources/Presentation/Common/Components/AgreementModalView/AgreementModalView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/AgreementModalView/AgreementModalView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SnapKit
+import SafariServices
 
 final class AgreementModalView: UIView {
 
@@ -125,19 +126,22 @@ final class AgreementModalView: UIView {
             self?.setAllAgreement(to: isChecked)
         }
 
-        serviceAgree.onTapLink = {
-            if let url = URL(string: "https://hilingual.com/terms/service") {
-                UIApplication.shared.open(url)
-            }
+        serviceAgree.onTapLink = { [weak self] in
+            guard let url = URL(string: "https://hilingual.notion.site/230829677ebf817a8091f49423cbbb11"),
+                  let vc = self?.parentViewController() else { return }
+            let safariVC = SFSafariViewController(url: url)
+            vc.present(safariVC, animated: true)
         }
 
-        privacyAgree.onTapLink = {
-            if let url = URL(string: "https://hilingual.com/terms/privacy") {
-                UIApplication.shared.open(url)
-            }
+        privacyAgree.onTapLink = { [weak self] in
+            guard let url = URL(string: "https://hilingual.notion.site/230829677ebf8104b52ce74c65c27607"),
+                  let vc = self?.parentViewController() else { return }
+            let safariVC = SFSafariViewController(url: url)
+            vc.present(safariVC, animated: true)
         }
 
         marketingAgree.onTapLink = nil
+
         [serviceAgree, privacyAgree, marketingAgree].forEach {
             $0.onToggle = { [weak self] _ in
                 self?.updateAgreementState()
@@ -147,8 +151,7 @@ final class AgreementModalView: UIView {
         updateAgreementState()
     }
 
-
-    // MARK: - Logic
+    // MARK: - Private Methods
 
     private func setAllAgreement(to checked: Bool) {
         [serviceAgree, privacyAgree, marketingAgree].forEach { $0.isChecked = checked }

--- a/HilingualPresentation/Sources/Presentation/Common/Components/nickNameTextField.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/nickNameTextField.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-final class TextField: BaseUIView {
+final class nickNameTextField: BaseUIView {
 
     public enum State {
         case normal
@@ -207,8 +207,10 @@ final class TextField: BaseUIView {
     @objc
     private func textDidChange() {
         let current = textField.text ?? ""
-        let trimmed = current.count > maxLength ? String(current.prefix(maxLength)) : current
+        let noSpaces = current.replacingOccurrences(of: " ", with: "")
+        let trimmed = noSpaces.count > maxLength ? String(noSpaces.prefix(maxLength)) : noSpaces
         textField.attributedText = .suit(.body_sb_16, text: trimmed)
         updateCharacterCount()
     }
+
 }

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/UIView+.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/UIView+.swift
@@ -12,4 +12,15 @@ extension UIView {
     func addSubviews(_ views: UIView...) {
         views.forEach { self.addSubview($0) }
     }
+
+    func parentViewController() -> UIViewController? {
+        var parentResponder: UIResponder? = self
+        while let responder = parentResponder {
+            if let vc = responder as? UIViewController {
+                return vc
+            }
+            parentResponder = responder.next
+        }
+        return nil
+    }
 }

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/EditProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/EditProfileView.swift
@@ -29,14 +29,6 @@ final class EditProfileView: BaseUIView {
         return modal
     }()
 
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "내 정보 수정"
-        label.textColor = .black
-        label.font = .suit(.head_b_18)
-        return label
-    }()
-
     let profileImageView = EditableProfileImageView()
 
     let nicknameRow = ProfileRow(title: "닉네임", value: "sereal")
@@ -54,7 +46,7 @@ final class EditProfileView: BaseUIView {
 
     override func setUI() {
         backgroundColor = .white
-        addSubviews(backButton, titleLabel, profileImageView, nicknameRow, socialRow, withdrawButton, modal)
+        addSubviews(backButton, profileImageView, nicknameRow, socialRow, withdrawButton, modal)
         configureModal()
     }
 
@@ -67,11 +59,6 @@ final class EditProfileView: BaseUIView {
             $0.top.equalToSuperview().inset(16)
             $0.leading.equalToSuperview().inset(16)
             $0.size.equalTo(24)
-        }
-
-        titleLabel.snp.makeConstraints {
-            $0.centerY.equalTo(backButton)
-            $0.centerX.equalToSuperview()
         }
 
         profileImageView.snp.makeConstraints {

--- a/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageView.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageView.swift
@@ -23,6 +23,7 @@ final class MypageView: BaseUIView {
     // MARK: - Public
 
     var onMenuTap: ((MenuItem) -> Void)?
+    var onEditProfileTap: (() -> Void)?
 
     // MARK: - UI Components
 
@@ -147,6 +148,8 @@ final class MypageView: BaseUIView {
             menuCardView.addSubview(row)
             menuRows.append(row)
         }
+
+        addGesture()
     }
 
     override func setLayout() {
@@ -271,7 +274,25 @@ final class MypageView: BaseUIView {
         container.addAction(UIAction { _ in action() }, for: .touchUpInside)
         return container
     }
+
+    private func addGesture() {
+        let imageTapGesture = UITapGestureRecognizer(target: self, action: #selector(handleEditProfileTap))
+        profileImageView.isUserInteractionEnabled = true
+        profileImageView.addGestureRecognizer(imageTapGesture)
+
+        let nicknameTapGesture = UITapGestureRecognizer(target: self, action: #selector(handleEditProfileTap))
+        nicknameLabel.isUserInteractionEnabled = true
+        nicknameLabel.addGestureRecognizer(nicknameTapGesture)
+    }
+
+    //MARK: - Actions
+
+    @objc private func handleEditProfileTap() {
+        onEditProfileTap?()
+    }
 }
+
+//MARK: - Extension
 
 extension MypageView {
     public func configure(nickname: String, profileImageURL: String?) {

--- a/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageView.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageView.swift
@@ -55,7 +55,8 @@ final class MypageView: BaseUIView {
     let profileImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = .gray200
-        imageView.layer.cornerRadius = 32
+        imageView.layer.cornerRadius = 30
+        imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         imageView.layer.borderWidth = 1
         imageView.layer.borderColor = UIColor.gray200.cgColor

--- a/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageViewController.swift
@@ -7,7 +7,6 @@
 
 import Combine
 import Foundation
-import UIKit
 import SafariServices
 
 public final class MypageViewController: BaseUIViewController<MypageViewModel> {
@@ -43,6 +42,10 @@ public final class MypageViewController: BaseUIViewController<MypageViewModel> {
         mypageView.logoutButton.addTarget(self, action: #selector(presentLogoutDialog), for: .touchUpInside)
         mypageView.editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
         mypageView.feedButton.addTarget(self, action: #selector(myFeedProfileButtonTapped), for: .touchUpInside)
+
+        mypageView.onEditProfileTap = { [weak self] in
+            self?.editButtonTapped()
+        }
 
         mypageView.onMenuTap = { [weak self] menu in
             guard let self else { return }

--- a/HilingualPresentation/Sources/Presentation/OnBoarding/OnBoardingView.swift
+++ b/HilingualPresentation/Sources/Presentation/OnBoarding/OnBoardingView.swift
@@ -48,8 +48,8 @@ final class OnBoardingView: BaseUIView {
         return label
     }()
 
-    let nicknameTextField: TextField = {
-        let textfield = TextField()
+    let nicknameTextField: nickNameTextField = {
+        let textfield = nickNameTextField()
         textfield.setPlaceholder("한글, 영문, 숫자 조합만 가능")
         return textfield
     }()

--- a/HilingualPresentation/Sources/Presentation/OnBoarding/OnBoardingViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/OnBoarding/OnBoardingViewModel.swift
@@ -72,13 +72,12 @@ public final class OnBoardingViewModel: BaseViewModel {
             .debounce(for: .milliseconds(1000), scheduler: RunLoop.main)
             .map { nickname in
                 self.useCase.checkDuplicate(nickname)
-                    .map { isAvailable in
-                        (nickname, isAvailable
-                         ? TextField.State.success("사용 가능한 닉네임이에요")
-                         : .error("이미 사용 중인 닉네임이에요."))
-                    }
-                    .catch { _ in
-                        Just((nickname, .error("중복 확인 중 오류가 발생했어요.")))
+                    .map { (isAvailable, message) in
+                        if isAvailable {
+                            return (nickname, TextField.State.success(message ?? "사용 가능한 닉네임이에요"))
+                        } else {
+                            return (nickname, TextField.State.error(message ?? "이미 사용 중인 닉네임이에요."))
+                        }
                     }
                     .eraseToAnyPublisher()
             }
@@ -88,6 +87,7 @@ public final class OnBoardingViewModel: BaseViewModel {
                 let (responseNickname, state) = response
                 return responseNickname == currentNickname ? state : nil
             }
+
 
         let nicknameState = Publishers.Merge(nicknameValidatoinState, nicknameDupicateState)
             .share()

--- a/HilingualPresentation/Sources/Presentation/OnBoarding/OnBoardingViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/OnBoarding/OnBoardingViewModel.swift
@@ -19,7 +19,7 @@ public final class OnBoardingViewModel: BaseViewModel {
     }
 
     public struct Output {
-        let nicknameState: AnyPublisher<TextField.State, Never>
+        let nicknameState: AnyPublisher<nickNameTextField.State, Never>
         let startButtonEnabled: AnyPublisher<Bool, Never>
         let signUpResult: AnyPublisher<Void, Never>
     }
@@ -52,7 +52,7 @@ public final class OnBoardingViewModel: BaseViewModel {
             .share()
 
         let nicknameValidatoinState = nicknameChanged
-            .map { [weak self] nickname -> TextField.State in
+            .map { [weak self] nickname -> nickNameTextField.State in
                 guard let self else { return .normal }
 
                 switch useCase.validate(nickname) {
@@ -74,9 +74,9 @@ public final class OnBoardingViewModel: BaseViewModel {
                 self.useCase.checkDuplicate(nickname)
                     .map { (isAvailable, message) in
                         if isAvailable {
-                            return (nickname, TextField.State.success(message ?? "사용 가능한 닉네임이에요"))
+                            return (nickname, nickNameTextField.State.success(message ?? "사용 가능한 닉네임이에요"))
                         } else {
-                            return (nickname, TextField.State.error(message ?? "이미 사용 중인 닉네임이에요."))
+                            return (nickname, nickNameTextField.State.error(message ?? "이미 사용 중인 닉네임이에요."))
                         }
                     }
                     .eraseToAnyPublisher()

--- a/HilingualPresentation/Sources/Presentation/Splash/SplashViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/Splash/SplashViewModel.swift
@@ -105,8 +105,8 @@ public final class SplashViewModel: BaseViewModel {
                         print("[SplashVM] 홈 화면 이동")
                         self?.homeSubject.send()
                     } else {
-                        print("[SplashVM] 온보딩 화면 이동")
-                        self?.onboardingSubject.send()
+                        print("[SplashVM] 로그인 화면 이동")
+                        self?.loginSubject.send()
                     }
                 }
             )

--- a/HilingualPresentation/Sources/Presentation/VerificationCode/VerificationCodeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/VerificationCode/VerificationCodeViewController.swift
@@ -82,6 +82,7 @@ public final class VerificationCodeViewController: BaseUIViewController<Verifica
         }
 
         verificationCodeView.submitButton.addTarget(self, action: #selector(submitTapped), for: .touchUpInside)
+        verificationCodeView.notReceivedButton.addTarget(self, action: #selector(policyButtonTapped), for: .touchUpInside)
     }
 
     // MARK: - Action
@@ -90,18 +91,17 @@ public final class VerificationCodeViewController: BaseUIViewController<Verifica
         let code = verificationCodeView.codeView.text
         viewModel?.submit(code: code)
     }
+    @objc private func policyButtonTapped() {
+        guard let url = URL(string: "http://pf.kakao.com/_kNTvn/chat") else { return }
+        let safariVC = SFSafariViewController(url: url)
+        self.present(safariVC, animated: true, completion: nil)
+    }
 
     private func dialogConfigure() {
 
     }
 
     // MARK: - Private Method
-
-    private func policyButtonTapped() {
-        guard let url = URL(string: "http://pf.kakao.com/_kNTvn/chat") else { return }
-        let safariVC = SFSafariViewController(url: url)
-        self.present(safariVC, animated: true, completion: nil)
-    }
 
     private func exitApp() {
         UIApplication.shared.perform(#selector(NSXPCConnection.suspend))

--- a/HilingualPresentation/Sources/Presentation/VerificationCode/VerificationCodeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/VerificationCode/VerificationCodeViewController.swift
@@ -98,7 +98,7 @@ public final class VerificationCodeViewController: BaseUIViewController<Verifica
     // MARK: - Private Method
 
     private func policyButtonTapped() {
-        guard let url = URL(string: "https://pf.kakao.com/_kNTvn/chat") else { return }
+        guard let url = URL(string: "http://pf.kakao.com/_kNTvn/chat") else { return }
         let safariVC = SFSafariViewController(url: url)
         self.present(safariVC, animated: true, completion: nil)
     }


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #290 

---

## 📎 Work Description 
- 프로필 이미지 찌그러짐 문제 + 비율을 ".scaleAspectFill"로 방식으로 변경했습니다 https://peppo.tistory.com/75
- 해결한 문제나 핵심 내용을 요약해서 적어주세요.
- 로그아웃 api를 연결했습니다
- 약관링크 클릭시 외부 탭이 아니라 앱내 뷰로 이동할수 있게끔 구현했습니다 
    기존에는 모달이나, 다른 뷰들을 찾으실때 window에 접근해서 찾아야했던 불편함이 있어서 실제로 뷰를 띄워줄 부모 뷰를 찾아주는 유틸을 만들었습니다. 
```swift

    func parentViewController() -> UIViewController? {
        var parentResponder: UIResponder? = self
        while let responder = parentResponder {
            if let vc = responder as? UIViewController {
                return vc
            }
            parentResponder = responder.next
        }
        return nil
    }
```
함수 원형은 위와 같고 활용은 
```swift

        serviceAgree.onTapLink = { [weak self] in
            guard let url = URL(string: "https://hilingual.notion.site/230829677ebf817a8091f49423cbbb11"),
                  let vc = self?.parentViewController() else { return }
            let safariVC = SFSafariViewController(url: url)
            vc.present(safariVC, animated: true)
        }
```
이런식으로 활용가능합니다!
- 닉네임 띄어쓰기 방지 로직을 추가했습니다
- 닉네임 중복시 서버에서 어떤 에러든 하나의 에러로 처리했는데, 이제는 서버에서 전달해주는 메세지를 helperText에 보여줍니다
- 인증코드 실패후 다시 앱을 실행했을때 로그인부터 진행되게끔했습니다
- 인증코드 카카오톡 문의 채널을 연결했습니다
---

## 📷 Screenshots  


| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/ef6c0ff9-0252-45fb-a399-2f73467f203d" width="250"> | <img src="https://github.com/user-attachments/assets/b74745a7-506e-4172-aebd-840e94151302" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
