### PR TITLE
[fix] 스티키헤더 푸터 계산로직 수정

### DIFF
--- a/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
@@ -63,6 +63,7 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
         feedCellView.tableView.delegate = self
         feedCellView.tableView.dataSource = feedCellView
         feedCellView.tableView.alwaysBounceVertical = false
+        feedCellView.tableView.bounces = false
         
         feedCellView.addTableTapGesture(target: self, action: #selector(didTapTableView))
         
@@ -198,7 +199,7 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
         }
         else if contentHeightWithoutFooter > fixedSafeAreaHeight - 195 {
             let footer = UIView()
-            footer.frame.size.height = 115
+            footer.frame.size.height = 120
             tableView.tableFooterView = footer
         }
         else {

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
@@ -198,7 +198,7 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
         }
         else if contentHeightWithoutFooter > fixedSafeAreaHeight - 195 {
             let footer = UIView()
-            footer.frame.size.height = 110
+            footer.frame.size.height = 115
             tableView.tableFooterView = footer
         }
         else {

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
@@ -31,7 +31,6 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
     private let type: FeedProfileListType
     
     private(set) var currentFeeds: [FeedModel] = []
-    private var isFooterApplied = false
     
     var onHideTapped: ((Int) -> Void)?
     var onReportTapped: (() -> Void)?
@@ -59,8 +58,8 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
         
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(didTopScrollRefresh), for: .valueChanged)
-        
         feedCellView.tableView.refreshControl = refreshControl
+        
         feedCellView.tableView.delegate = self
         feedCellView.tableView.dataSource = feedCellView
         feedCellView.tableView.alwaysBounceVertical = false
@@ -70,26 +69,20 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
         feedCellView.onHideTapped = { [weak self] row in
             self?.onHideTapped?(row)
         }
-        
         feedCellView.onReportTapped = { [weak self] in
             self?.onReportTapped?()
         }
-        
         feedCellView.onProfileTapped = { [weak self] row in
             guard let self else { return }
             let user = self.currentFeeds[row]
             
             let targetId = self.viewModel?.targetUserId ?? 0
-            
-            if user.isMine || Int64(user.userID) == targetId {
-                return
-            }
+            if user.isMine || Int64(user.userID) == targetId { return }
             
             let vc = self.diContainer.makeUserFeedProfileViewController(userId: Int64(user.userID))
             vc.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(vc, animated: true)
         }
-
         feedCellView.onFeedTextTapped = { [weak self] row in
             guard let self else { return }
             let feed = self.currentFeeds[row]
@@ -97,7 +90,6 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
             vc.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(vc, animated: true)
         }
-        
         feedCellView.onFeedImageTapped = { [weak self] row in
             guard let self else { return }
             let feed = self.currentFeeds[row]
@@ -105,7 +97,6 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
             vc.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(vc, animated: true)
         }
-
         feedCellView.onDetailTapped = { [weak self] row in
             guard let self else { return }
             let feed = self.currentFeeds[row]
@@ -113,6 +104,11 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
             vc.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(vc, animated: true)
         }
+    }
+    
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        footerForStickyHeader()
     }
     
     // MARK: - Bind
@@ -140,10 +136,6 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
                         }
                     }
                 }
-
-                DispatchQueue.main.async {
-                    self.footerForStickyHeader()
-                }
             }
             .store(in: &cancellables)
     }
@@ -158,10 +150,6 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
             emptyMessage: type.emptyMessage,
             type: type
         )
-        
-        DispatchQueue.main.async {
-            self.footerForStickyHeader()
-        }
     }
     
     public func resetScrollPosition() {
@@ -188,11 +176,12 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
     // MARK: - Private Method
     
     private func footerForStickyHeader() {
-        guard !isFooterApplied else { return }
         
         let tableView = feedCellView.tableView
         tableView.layoutIfNeeded()
-        let contentHeight = tableView.contentSize.height
+        
+        let contentHeightWithoutFooter =
+        tableView.contentSize.height - (tableView.tableFooterView?.frame.height ?? 0)
         
         guard let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
@@ -203,20 +192,19 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
         let topInset = window.safeAreaInsets.top
         let bottomInset = window.safeAreaInsets.bottom
         let fixedSafeAreaHeight = screenHeight - topInset - bottomInset
-                
-        if contentHeight > fixedSafeAreaHeight - 100 {
+        
+        if contentHeightWithoutFooter > fixedSafeAreaHeight - 100 {
             tableView.tableFooterView = nil
         }
-        else if contentHeight > fixedSafeAreaHeight - 195 {
+        else if contentHeightWithoutFooter > fixedSafeAreaHeight - 195 {
             let footer = UIView()
             footer.backgroundColor = .red
-            footer.frame.size.height = 110
+            footer.frame.size.height = 120
             tableView.tableFooterView = footer
         }
         else {
             tableView.tableFooterView = nil
         }
-        isFooterApplied = true
     }
 }
 

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
@@ -198,7 +198,7 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
         }
         else if contentHeightWithoutFooter > fixedSafeAreaHeight - 195 {
             let footer = UIView()
-            footer.frame.size.height = 120
+            footer.frame.size.height = 110
             tableView.tableFooterView = footer
         }
         else {

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
@@ -198,7 +198,6 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
         }
         else if contentHeightWithoutFooter > fixedSafeAreaHeight - 195 {
             let footer = UIView()
-            footer.backgroundColor = .red
             footer.frame.size.height = 120
             tableView.tableFooterView = footer
         }

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileView.swift
@@ -48,7 +48,7 @@ final class MyFeedProfileView: BaseUIView {
             streak: streak
         )
     }
-
+    
     func configureSegmentedControl(
         parentVC: UIViewController,
         viewControllers: [UIViewController],
@@ -61,7 +61,7 @@ final class MyFeedProfileView: BaseUIView {
         )
         self.segmentedControl = control
         addSubview(control)
-
+        
         control.snp.makeConstraints {
             segmentedTopConstraint = $0.top.equalTo(myFeedView.snp.bottom).offset(20).constraint
             $0.horizontalEdges.equalToSuperview()
@@ -72,7 +72,7 @@ final class MyFeedProfileView: BaseUIView {
             self?.onSegmentChanged?(index)
         }
     }
-
+    
     func setFollowSectionTappedAction(_ action: @escaping () -> Void) {
         myFeedView.onFollowSectionTapped = action
     }
@@ -81,10 +81,17 @@ final class MyFeedProfileView: BaseUIView {
         guard let segmentedTopConstraint else { return }
         
         let progress = min(max(offsetY / 84, 0), 1)
-        myFeedView.alpha = 1 - progress
-        myFeedView.transform = CGAffineTransform(translationX: 0, y: -progress * 40)
-        
+        let alphaValue = 1 - progress * 1.4
+        let transformValue = CGAffineTransform(translationX: 0, y: -progress * 40)
         let newOffset = max(20 - offsetY, -84)
-        segmentedTopConstraint.update(offset: newOffset)
+        
+        UIView.animate(
+            withDuration: 0.15, delay: 0,
+            options: [.curveEaseOut, .allowUserInteraction]) {
+            self.myFeedView.alpha = alphaValue
+            self.myFeedView.transform = transformValue
+            segmentedTopConstraint.update(offset: newOffset)
+            self.layoutIfNeeded()
+        }
     }
 }

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/UserFeed/UserFeedProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/UserFeed/UserFeedProfileView.swift
@@ -11,6 +11,7 @@ import SnapKit
 final class UserFeedProfileView: BaseUIView {
     
     // MARK: - Callbacks
+    
     var onFollowTapped: ((FollowButtonState) -> Void)?
     var onBlockTapped: (() -> Void)?
     var onBlockConfirmTapped: (() -> Void)?
@@ -18,6 +19,7 @@ final class UserFeedProfileView: BaseUIView {
     var onUnblockTapped: (() -> Void)?
 
     // MARK: - UI Components
+    
     private let userFeedView = FeedUserProfile()
     private(set) var button = FollowButton()
     private var feedTopConstraint: Constraint?
@@ -55,6 +57,7 @@ final class UserFeedProfileView: BaseUIView {
     private let blockModal = BlockModal()
     
     // MARK: - Setup
+    
     override func setUI() {
         addSubviews(userFeedView, button, feedContainer, blockedStack, modal)
         blockedStack.isHidden = true
@@ -124,8 +127,16 @@ final class UserFeedProfileView: BaseUIView {
     }
     
     func updateFeedContainer(offsetY: CGFloat) {
-        let newOffset = max(133 - offsetY, 0)
-        feedTopConstraint?.update(offset: newOffset)
+        let newOffset = max(133 - offsetY * 1.3, 0)
+
+        UIView.animate(withDuration: 0.3,
+                       delay: 0,
+                       usingSpringWithDamping: 0.85,
+                       initialSpringVelocity: 0.5,
+                       options: [.allowUserInteraction]) {
+            self.feedTopConstraint?.update(offset: newOffset)
+            self.layoutIfNeeded()
+        }
     }
     
     func showModal() {
@@ -192,6 +203,7 @@ final class UserFeedProfileView: BaseUIView {
     }
     
     // MARK: - Private
+    
     @objc private func buttonTapped() {
         switch button.currentState {
         case .unblock:


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #298

---

## 📎 Work Description 
- 스티키 헤더와 푸터 관련 문제를 수정했습니다.

로그를 찍어보니... 콘텐츠(테이블 뷰)의 높이가 0으로 계산되어 푸터가 정상적으로 추가되지 않는 문제가 있었습니다. 원인은 AutoLayout이 아직 적용되기 전이라 contentSize가 확정되지 않았기 때문이며, 여기에 constraint update까지 겹치면서 레이아웃 사이클이 반복 실행되는 현상이 발생했습니다.

이 문제를 해결하기 위해, contentSize가 보장되는 시점인 viewDidLayoutSubviews()에서 푸터 로직을 실행하도록 변경했습니다.
```
    public override func viewDidLayoutSubviews() {
        super.viewDidLayoutSubviews()
        footerForStickyHeader()
    }
```

footer 추가 문제와 별개로, 스크롤 시 상단 부분이 떨리는 문제가 있었는데요. 

- 테이블뷰의 bounces 속성을 제거하여 떨림 현상을 방지했습니다!
- 마이 피드 프로필에서는 투명도 변화를 보다 자연스럽게 개선했습니다.
- 유저 피드 프로필에서는 스프링 애니메이션을 적용해 상단 스크롤 떨림 현상을 개선했습니다.

---

## 📷 Screenshots  
![Simulator Screen Recording - iPhone 11 Pro - 2025-09-14 at 20 07 43](https://github.com/user-attachments/assets/12f597b5-8fd2-49a1-97fb-1f537887ccbf)



---

## 💬 To Reviewers  
(09.14 수정) 덜덜거리는 이슈 해결 완. 
교훈: **viewDidLayoutSubviews**을 기억하자
