### PR TITLE
[refactor] 홈 캘린더 API 수정

### DIFF
--- a/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchEmptyView.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedSearch/FeedSearchEmptyView.swift
@@ -13,7 +13,7 @@ final class FeedSearchEmptyView: BaseUIView {
     
     private let emptyLabel: UILabel = {
         let label = UILabel()
-        label.text = "검색 결과가 없습니다."
+        label.text = "검색 결과가 없어요."
         label.font = .suit(.head_m_18)
         label.textColor = .gray500
         label.textAlignment = .center

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -57,109 +57,15 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         homeView.calendarView.reload(for: today)
         homeView.selectedInfo.setSelectedDate(today)
         
+        self.fetchAndShowDateInfo(for: today)
+        
         homeView.calendarView.onDateSelected = { [weak self] date in
-            guard let self else { return }
-            
-            let requestedDate = date
-            let calendar = Calendar.current
-            let today = Calendar.current.startOfDay(for: Date())
-            let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
-            let selectedDay = Calendar.current.startOfDay(for: requestedDate)
-            
-            self.homeView.selectedInfo.setSelectedDate(requestedDate)
-            self.homeView.selectedInfo.currentDiaryId = nil
-            
-            // 1) 미래 날짜면 바로 Lock 상태로 보여주고 네트워크 호출하지 않음
-            if selectedDay > today {
-                self.currentDateRequestCancellable?.cancel()
-                self.homeView.selectedInfo.updateView(
-                    for: requestedDate,
-                    diaryId: nil,
-                    isPublished: nil,
-                    remainingTime: 0,
-                    topicData: nil,
-                    diaryData: nil,
-                    imageURL: nil
-                )
-                return
-            }
-            
-            let isDiaryDate = self.homeView.calendarView.filledDates.contains {
-                Calendar.current.isDate($0, inSameDayAs: requestedDate)
-            }
-            
-            if isDiaryDate {
-                // 일기가 있는 경우, 기존 로직대로 일기 정보를 가져옴
-                self.currentDateRequestCancellable = self.viewModel?.fetchDiary(for: requestedDate)
-                    .receive(on: RunLoop.main)
-                    .sink(receiveCompletion: { completion in
-                    }, receiveValue: { [weak self] diary in
-                        guard let self else { return }
-                        self.homeView.selectedInfo.updateView(
-                            for: requestedDate,
-                            diaryId: diary?.diaryId,
-                            isPublished: diary?.isPublished,
-                            remainingTime: 0,
-                            topicData: nil,
-                            diaryData: diary?.originalText,
-                            imageURL: diary?.imageUrl
-                        )
-                    })
-            } else {
-                // 일기가 없는 경우, 오늘 또는 어제 날짜에 대해서만 fetchTopic 호출
-                if calendar.isDate(requestedDate, inSameDayAs: today) || calendar.isDate(requestedDate, inSameDayAs: yesterday) {
-                    self.currentDateRequestCancellable = self.viewModel?.fetchTopic(for: requestedDate)
-                        .receive(on: RunLoop.main)
-                        .sink(receiveCompletion: { completion in
-                            if case .failure = completion {
-                                self.homeView.selectedInfo.updateView(
-                                    for: requestedDate,
-                                    diaryId: nil,
-                                    isPublished: nil,
-                                    remainingTime: 0,
-                                    topicData: nil,
-                                    diaryData: nil,
-                                    imageURL: nil
-                                )
-                            }
-                        }, receiveValue: { [weak self] topic in
-                            guard let self else { return }
-                            let remaining = max(0, topic?.remainingTime ?? 0)
-                            
-                            var topicData: (String, String)? = nil
-                            if remaining > 0 {
-                                topicData = topic.map { ($0.topicKor, $0.topicEn) }
-                            }
-                            
-                            self.homeView.selectedInfo.updateView(
-                                for: requestedDate,
-                                diaryId: nil,
-                                isPublished: nil,
-                                remainingTime: remaining,
-                                topicData: topicData,
-                                diaryData: nil,
-                                imageURL: nil
-                            )
-                        })
-                } else {
-                    // 오늘/어제가 아닌데 일기가 없는 경우, 뷰를 초기화
-                    self.homeView.selectedInfo.updateView(
-                        for: requestedDate,
-                        diaryId: nil,
-                        isPublished: nil,
-                        remainingTime: 0,
-                        topicData: nil,
-                        diaryData: nil,
-                        imageURL: nil
-                    )
-                }
-            }
-            self.currentDateRequestCancellable?.store(in: &self.viewModel!.cancellables)
+            self?.fetchAndShowDateInfo(for: date)
         }
         
         homeView.onMonthChanged = { [weak self] year, month in
-            guard self != nil else { return }
-            self?.homeView.selectedInfo.reset()
+            guard let self else { return }
+            self.homeView.selectedInfo.reset()
             
             let calendar = Calendar.current
             let today = Date()
@@ -174,13 +80,12 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
                 selectedDate = calendar.date(from: DateComponents(year: year, month: month, day: 1))!
             }
             
-            self?.homeView.calendarView.select(date: selectedDate)
-            self?.input.monthChange.send((year, month))
+            self.homeView.calendarView.select(date: selectedDate)
+            self.input.monthChange.send((year, month))
         }
         
         let output = viewModel.transform(input: input)
         
-        // 사용자 정보 바인딩
         output.userInfo
             .receive(on: RunLoop.main)
             .sink(receiveCompletion: { completion in
@@ -198,15 +103,11 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
             })
             .store(in: &viewModel.cancellables)
         
-        // filledDates를 calendarView에 반영 + 선택한 날짜 일기/주제 보여줌
         output.filledDates
             .receive(on: RunLoop.main)
             .sink { [weak self] dates in
                 guard let self else { return }
                 self.homeView.calendarView.filledDates = dates
-                
-                let selected = self.homeView.calendarView.selectedDate ?? Date()
-                self.homeView.calendarView.onDateSelected?(selected)
             }
             .store(in: &viewModel.cancellables)
     }
@@ -267,6 +168,101 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     }
     
     //MARK: - Private Methods
+    
+    private func fetchAndShowDateInfo(for date: Date) {
+        self.currentDateRequestCancellable?.cancel()
+        
+        let requestedDate = date
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
+        let selectedDay = calendar.startOfDay(for: requestedDate)
+        
+        self.homeView.selectedInfo.setSelectedDate(requestedDate)
+        self.homeView.selectedInfo.currentDiaryId = nil
+        
+        if selectedDay > today {
+            self.homeView.selectedInfo.updateView(
+                for: requestedDate,
+                diaryId: nil,
+                isPublished: nil,
+                remainingTime: 0,
+                topicData: nil,
+                diaryData: nil,
+                imageURL: nil
+            )
+            return
+        }
+        
+        let isDiaryDate = self.homeView.calendarView.filledDates.contains {
+            calendar.isDate($0, inSameDayAs: requestedDate)
+        }
+        
+        if isDiaryDate {
+            self.currentDateRequestCancellable = self.viewModel?.fetchDiary(for: requestedDate)
+                .receive(on: RunLoop.main)
+                .sink(receiveCompletion: { completion in
+                }, receiveValue: { [weak self] diary in
+                    guard let self else { return }
+                    self.homeView.selectedInfo.updateView(
+                        for: requestedDate,
+                        diaryId: diary?.diaryId,
+                        isPublished: diary?.isPublished,
+                        remainingTime: 0,
+                        topicData: nil,
+                        diaryData: diary?.originalText,
+                        imageURL: diary?.imageUrl
+                    )
+                })
+        } else {
+            if calendar.isDate(requestedDate, inSameDayAs: today) || calendar.isDate(requestedDate, inSameDayAs: yesterday) {
+                self.currentDateRequestCancellable = self.viewModel?.fetchTopic(for: requestedDate)
+                    .receive(on: RunLoop.main)
+                    .sink(receiveCompletion: { completion in
+                        if case .failure = completion {
+                            self.homeView.selectedInfo.updateView(
+                                for: requestedDate,
+                                diaryId: nil,
+                                isPublished: nil,
+                                remainingTime: 0,
+                                topicData: nil,
+                                diaryData: nil,
+                                imageURL: nil
+                            )
+                        }
+                    }, receiveValue: { [weak self] topic in
+                        guard let self else { return }
+                        let remaining = max(0, topic?.remainingTime ?? 0)
+                        
+                        var topicData: (String, String)? = nil
+                        if remaining > 0 {
+                            topicData = topic.map { ($0.topicKor, $0.topicEn) }
+                        }
+                        
+                        self.homeView.selectedInfo.updateView(
+                            for: requestedDate,
+                            diaryId: nil,
+                            isPublished: nil,
+                            remainingTime: remaining,
+                            topicData: topicData,
+                            diaryData: nil,
+                            imageURL: nil
+                        )
+                    })
+            } else {
+                self.homeView.selectedInfo.updateView(
+                    for: requestedDate,
+                    diaryId: nil,
+                    isPublished: nil,
+                    remainingTime: 0,
+                    topicData: nil,
+                    diaryData: nil,
+                    imageURL: nil
+                )
+            }
+        }
+        self.currentDateRequestCancellable?.store(in: &self.viewModel!.cancellables)
+    }
     
     private func showOverlay() {
         guard let containerView = tabBarController?.view ?? view else { return }

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -30,26 +30,12 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         navigationController?.setNavigationBarHidden(true, animated: false)
         
         let selectedDate = homeView.calendarView.selectedDate ?? Date()
-        
         fetchAndShowDateInfo(for: selectedDate)
         
         let calendar = Calendar.current
         let year = calendar.component(.year, from: selectedDate)
         let month = calendar.component(.month, from: selectedDate)
         input.monthChange.send((year, month))
-        
-        viewModel?.fetchUserInfo()
-            .receive(on: RunLoop.main)
-            .sink(receiveCompletion: { _ in }, receiveValue: { [weak self] entity in
-                self?.homeView.profileView.updateView(
-                    nickname: entity.nickname,
-                    profileImageURL: entity.profileImg,
-                    totalDiaries: entity.totalDiaries,
-                    streak: entity.streak,
-                    newAlarm: entity.newAlarm
-                )
-            })
-            .store(in: &viewModel!.cancellables)
     }
     
     // MARK: - Bind
@@ -59,8 +45,6 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         homeView.calendarView.selectedDate = today
         homeView.calendarView.reload(for: today)
         homeView.selectedInfo.setSelectedDate(today)
-        
-        self.fetchAndShowDateInfo(for: today)
         
         homeView.calendarView.onDateSelected = { [weak self] date in
             self?.fetchAndShowDateInfo(for: date)

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -30,6 +30,9 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         navigationController?.setNavigationBarHidden(true, animated: false)
         
         let selectedDate = homeView.calendarView.selectedDate ?? Date()
+        
+        fetchAndShowDateInfo(for: selectedDate)
+        
         let calendar = Calendar.current
         let year = calendar.component(.year, from: selectedDate)
         let month = calendar.component(.month, from: selectedDate)

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -29,6 +29,8 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
         
+        refreshUserInfo()
+        homeView.selectedInfo.reset()
         let selectedDate = homeView.calendarView.selectedDate ?? Date()
         let calendar = Calendar.current
         let year = calendar.component(.year, from: selectedDate)
@@ -497,5 +499,22 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         let myFeedProfileVC = diContainer.makeMyFeedProfileViewController()
         myFeedProfileVC.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(myFeedProfileVC, animated: true)
+    }
+    
+    // MARK: - Recall
+    
+    private func refreshUserInfo() {
+        viewModel?.fetchUserInfo()
+            .receive(on: RunLoop.main)
+            .sink(receiveCompletion: { _ in }, receiveValue: { [weak self] entity in
+                self?.homeView.profileView.updateView(
+                    nickname: entity.nickname,
+                    profileImageURL: entity.profileImg,
+                    totalDiaries: entity.totalDiaries,
+                    streak: entity.streak,
+                    newAlarm: entity.newAlarm
+                )
+            })
+            .store(in: &viewModel!.cancellables)
     }
 }

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -30,8 +30,6 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         navigationController?.setNavigationBarHidden(true, animated: false)
         
         let selectedDate = homeView.calendarView.selectedDate ?? Date()
-        fetchAndShowDateInfo(for: selectedDate)
-        
         let calendar = Calendar.current
         let year = calendar.component(.year, from: selectedDate)
         let month = calendar.component(.month, from: selectedDate)
@@ -45,31 +43,39 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         homeView.calendarView.selectedDate = today
         homeView.calendarView.reload(for: today)
         homeView.selectedInfo.setSelectedDate(today)
-        
+
         homeView.calendarView.onDateSelected = { [weak self] date in
             self?.fetchAndShowDateInfo(for: date)
         }
         
         homeView.onMonthChanged = { [weak self] year, month in
-            guard let self else { return }
-            self.homeView.selectedInfo.reset()
+            guard let self = self else { return }
             
             let calendar = Calendar.current
             let today = Date()
-            
-            let todayYear = calendar.component(.year, from: today)
-            let todayMonth = calendar.component(.month, from: today)
-            
             let selectedDate: Date
-            if year == todayYear && month == todayMonth {
+            if year == calendar.component(.year, from: today) &&
+               month == calendar.component(.month, from: today) {
                 selectedDate = today
             } else {
                 selectedDate = calendar.date(from: DateComponents(year: year, month: month, day: 1))!
             }
             
+            self.homeView.selectedInfo.updateView(
+                for: selectedDate,
+                diaryId: nil,
+                isPublished: nil,
+                remainingTime: 0,
+                topicData: nil,
+                diaryData: nil,
+                imageURL: nil
+            )
+            self.homeView.selectedInfo.reset()
             self.homeView.calendarView.select(date: selectedDate)
+            self.fetchAndShowDateInfo(for: selectedDate)
             self.input.monthChange.send((year, month))
         }
+
         
         let output = viewModel.transform(input: input)
         
@@ -95,6 +101,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
             .sink { [weak self] dates in
                 guard let self else { return }
                 self.homeView.calendarView.filledDates = dates
+                self.fetchAndShowDateInfo(for: self.homeView.calendarView.selectedDate ?? Date())
             }
             .store(in: &viewModel.cancellables)
     }
@@ -159,18 +166,19 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     private func fetchAndShowDateInfo(for date: Date) {
         self.currentDateRequestCancellable?.cancel()
         
-        let requestedDate = date
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
         let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
-        let selectedDay = calendar.startOfDay(for: requestedDate)
+        let selectedDay = calendar.startOfDay(for: date)
         
-        self.homeView.selectedInfo.setSelectedDate(requestedDate)
+        // 선택 날짜 초기화
+        self.homeView.selectedInfo.setSelectedDate(date)
         self.homeView.selectedInfo.currentDiaryId = nil
         
+        // 미래 날짜는 바로 리턴
         if selectedDay > today {
             self.homeView.selectedInfo.updateView(
-                for: requestedDate,
+                for: date,
                 diaryId: nil,
                 isPublished: nil,
                 remainingTime: 0,
@@ -182,72 +190,85 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         }
         
         let isDiaryDate = self.homeView.calendarView.filledDates.contains {
-            calendar.isDate($0, inSameDayAs: requestedDate)
+            calendar.isDate($0, inSameDayAs: date)
         }
         
         if isDiaryDate {
-            self.currentDateRequestCancellable = self.viewModel?.fetchDiary(for: requestedDate)
+            self.currentDateRequestCancellable = self.viewModel?.fetchDiary(for: date)
                 .receive(on: RunLoop.main)
-                .sink(receiveCompletion: { completion in
-                }, receiveValue: { [weak self] diary in
+                .sink(receiveCompletion: { _ in }, receiveValue: { [weak self] diary in
                     guard let self else { return }
-                    self.homeView.selectedInfo.updateView(
-                        for: requestedDate,
-                        diaryId: diary?.diaryId,
-                        isPublished: diary?.isPublished,
-                        remainingTime: 0,
-                        topicData: nil,
-                        diaryData: diary?.originalText,
-                        imageURL: diary?.imageUrl
-                    )
+                    
+                    if let diary {
+                        self.homeView.selectedInfo.updateView(
+                            for: date,
+                            diaryId: diary.diaryId,
+                            isPublished: diary.isPublished,
+                            remainingTime: 0,
+                            topicData: nil,
+                            diaryData: diary.originalText,
+                            imageURL: diary.imageUrl
+                        )
+                    } else {
+                        self.fetchTopicIfNeeded(for: date, today: today, yesterday: yesterday)
+                    }
                 })
         } else {
-            if calendar.isDate(requestedDate, inSameDayAs: today) || calendar.isDate(requestedDate, inSameDayAs: yesterday) {
-                self.currentDateRequestCancellable = self.viewModel?.fetchTopic(for: requestedDate)
-                    .receive(on: RunLoop.main)
-                    .sink(receiveCompletion: { completion in
-                        if case .failure = completion {
-                            self.homeView.selectedInfo.updateView(
-                                for: requestedDate,
-                                diaryId: nil,
-                                isPublished: nil,
-                                remainingTime: 0,
-                                topicData: nil,
-                                diaryData: nil,
-                                imageURL: nil
-                            )
-                        }
-                    }, receiveValue: { [weak self] topic in
-                        guard let self else { return }
-                        let remaining = max(0, topic?.remainingTime ?? 0)
-                        
-                        var topicData: (String, String)? = nil
-                        if remaining > 0 {
-                            topicData = topic.map { ($0.topicKor, $0.topicEn) }
-                        }
-                        
-                        self.homeView.selectedInfo.updateView(
-                            for: requestedDate,
-                            diaryId: nil,
-                            isPublished: nil,
-                            remainingTime: remaining,
-                            topicData: topicData,
-                            diaryData: nil,
-                            imageURL: nil
-                        )
-                    })
-            } else {
+            self.fetchTopicIfNeeded(for: date, today: today, yesterday: yesterday)
+        }
+        
+        self.currentDateRequestCancellable?.store(in: &self.viewModel!.cancellables)
+    }
+
+    // MARK: - Topic 조회 로직 분리
+    
+    private func fetchTopicIfNeeded(for date: Date, today: Date, yesterday: Date) {
+        let calendar = Calendar.current
+        let selectedDay = calendar.startOfDay(for: date)
+        
+        guard calendar.isDate(selectedDay, inSameDayAs: today) || calendar.isDate(selectedDay, inSameDayAs: yesterday) else {
+            self.homeView.selectedInfo.updateView(
+                for: date,
+                diaryId: nil,
+                isPublished: nil,
+                remainingTime: 0,
+                topicData: nil,
+                diaryData: nil,
+                imageURL: nil
+            )
+            return
+        }
+        
+        self.currentDateRequestCancellable = self.viewModel?.fetchTopic(for: date)
+            .receive(on: RunLoop.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                if case .failure = completion {
+                    self?.homeView.selectedInfo.updateView(
+                        for: date,
+                        diaryId: nil,
+                        isPublished: nil,
+                        remainingTime: 0,
+                        topicData: nil,
+                        diaryData: nil,
+                        imageURL: nil
+                    )
+                }
+            }, receiveValue: { [weak self] topic in
+                guard let self else { return }
+                let remaining = max(0, topic?.remainingTime ?? 0)
+                let topicData = remaining > 0 ? topic.map { ($0.topicKor, $0.topicEn) } : nil
+                
                 self.homeView.selectedInfo.updateView(
-                    for: requestedDate,
+                    for: date,
                     diaryId: nil,
                     isPublished: nil,
-                    remainingTime: 0,
-                    topicData: nil,
+                    remainingTime: remaining,
+                    topicData: topicData,
                     diaryData: nil,
                     imageURL: nil
                 )
-            }
-        }
+            })
+        
         self.currentDateRequestCancellable?.store(in: &self.viewModel!.cancellables)
     }
     

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -29,14 +29,12 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
         
-        // 월 정보 다시 요청 (최초에도!)
         let selectedDate = homeView.calendarView.selectedDate ?? Date()
         let calendar = Calendar.current
         let year = calendar.component(.year, from: selectedDate)
         let month = calendar.component(.month, from: selectedDate)
         input.monthChange.send((year, month))
         
-        // 사용자 정보도 다시 요청
         viewModel?.fetchUserInfo()
             .receive(on: RunLoop.main)
             .sink(receiveCompletion: { _ in }, receiveValue: { [weak self] entity in
@@ -63,7 +61,9 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
             guard let self else { return }
             
             let requestedDate = date
+            let calendar = Calendar.current
             let today = Calendar.current.startOfDay(for: Date())
+            let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
             let selectedDay = Calendar.current.startOfDay(for: requestedDate)
             
             self.homeView.selectedInfo.setSelectedDate(requestedDate)
@@ -84,14 +84,12 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
                 return
             }
             
-            // 2) 미래가 아니면 네트워크 처리 (기존 요청 취소)
-            self.currentDateRequestCancellable?.cancel()
-            
             let isDiaryDate = self.homeView.calendarView.filledDates.contains {
                 Calendar.current.isDate($0, inSameDayAs: requestedDate)
             }
             
             if isDiaryDate {
+                // 일기가 있는 경우, 기존 로직대로 일기 정보를 가져옴
                 self.currentDateRequestCancellable = self.viewModel?.fetchDiary(for: requestedDate)
                     .receive(on: RunLoop.main)
                     .sink(receiveCompletion: { completion in
@@ -108,37 +106,53 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
                         )
                     })
             } else {
-                self.currentDateRequestCancellable = self.viewModel?.fetchTopic(for: requestedDate)
-                    .receive(on: RunLoop.main)
-                    .sink(receiveCompletion: { completion in
-                        if case .failure = completion {
+                // 일기가 없는 경우, 오늘 또는 어제 날짜에 대해서만 fetchTopic 호출
+                if calendar.isDate(requestedDate, inSameDayAs: today) || calendar.isDate(requestedDate, inSameDayAs: yesterday) {
+                    self.currentDateRequestCancellable = self.viewModel?.fetchTopic(for: requestedDate)
+                        .receive(on: RunLoop.main)
+                        .sink(receiveCompletion: { completion in
+                            if case .failure = completion {
+                                self.homeView.selectedInfo.updateView(
+                                    for: requestedDate,
+                                    diaryId: nil,
+                                    isPublished: nil,
+                                    remainingTime: 0,
+                                    topicData: nil,
+                                    diaryData: nil,
+                                    imageURL: nil
+                                )
+                            }
+                        }, receiveValue: { [weak self] topic in
+                            guard let self else { return }
+                            let remaining = max(0, topic?.remainingTime ?? 0)
+                            
+                            var topicData: (String, String)? = nil
+                            if remaining > 0 {
+                                topicData = topic.map { ($0.topicKor, $0.topicEn) }
+                            }
+                            
                             self.homeView.selectedInfo.updateView(
                                 for: requestedDate,
                                 diaryId: nil,
                                 isPublished: nil,
-                                remainingTime: 0,
-                                topicData: nil,
+                                remainingTime: remaining,
+                                topicData: topicData,
                                 diaryData: nil,
                                 imageURL: nil
                             )
-                        }
-                    }, receiveValue: { [weak self] topic in
-                        guard let self else { return }
-                        let remaining = max(0, topic?.remainingTime ?? 0)
-                        let topicData = self.homeView.calendarView.filledDates.contains(where: {
-                            Calendar.current.isDate($0, inSameDayAs: requestedDate)
-                        }) ? nil : topic.map { ($0.topicKor, $0.topicEn) }
-                        
-                        self.homeView.selectedInfo.updateView(
-                            for: requestedDate,
-                            diaryId: nil,
-                            isPublished: nil,
-                            remainingTime: remaining,
-                            topicData: topicData,
-                            diaryData: nil,
-                            imageURL: nil
-                        )
-                    })
+                        })
+                } else {
+                    // 오늘/어제가 아닌데 일기가 없는 경우, 뷰를 초기화
+                    self.homeView.selectedInfo.updateView(
+                        for: requestedDate,
+                        diaryId: nil,
+                        isPublished: nil,
+                        remainingTime: 0,
+                        topicData: nil,
+                        diaryData: nil,
+                        imageURL: nil
+                    )
+                }
             }
             self.currentDateRequestCancellable?.store(in: &self.viewModel!.cancellables)
         }
@@ -162,18 +176,6 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
             
             self?.homeView.calendarView.select(date: selectedDate)
             self?.input.monthChange.send((year, month))
-            
-            self?.viewModel?.fetchUserInfo()
-                .receive(on: RunLoop.main)
-                .sink(receiveCompletion: { _ in }, receiveValue: { [weak self] entity in
-                    self?.homeView.profileView.updateView(
-                        nickname: entity.nickname,
-                        profileImageURL: entity.profileImg,
-                        totalDiaries: entity.totalDiaries,
-                        streak: entity.streak
-                    )
-                })
-                .store(in: &self!.viewModel!.cancellables)
         }
         
         let output = viewModel.transform(input: input)

--- a/HilingualPresentation/Sources/Presentation/WordBook/WordBookEmptyView.swift
+++ b/HilingualPresentation/Sources/Presentation/WordBook/WordBookEmptyView.swift
@@ -95,7 +95,7 @@ final class WordBookEmptyView: UIView {
         case .noSearchResult:
             emptyImageView.image = UIImage(named: "img_search_ios", in: .module, compatibleWith: nil)
             emptyImageView.isHidden = false
-            emptyLabel.text = "검색 결과가 없습니다."
+            emptyLabel.text = "검색 결과가 없어요."
             emptyButton.isHidden = true
         }
     }


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [x] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #315 

---

## 📎 Work Description 
- 엠티뷰 라이팅을 수정하였습니다.
- 두 번 호출되던 API 로그가 제대로 보입니다.
- remainingTime이 유효한 today와 yesterday만 fetchTopic이 호출 되도록 수정하였습니다.
- fetchAndShowDateInfo로 bind 메서드 내에 길게 자리잡고 있던 분기처리 로직을 분리하였습니다.
---

## 📷 Screenshots  


---

## 💬 To Reviewers  
- 제 브랜치로 와서 로그 더블 체크해주시면 감사하겠습니다.ᐟ.ᐟ 
- pull 받으셔서 아래 수정사항 확인 한 번 더 부탁드립니다🥹🥹
1. 첫 빌드 시 로그 중복되는 API 없는지 확인
2. 첫 빌드 홈화면에서 쓴 일기가 있다면 바로 보이는지 확인
3. 일기 작성 후 일기장 화면에서 백버튼으로 이동 시 일기가 바로 보이는지 확인