### PR TITLE
[refactor] 디자인 이슈 + 기능 이슈 해결

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/EditableProfileImageView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/EditableProfileImageView.swift
@@ -30,7 +30,7 @@ final class EditableProfileImageView: UIView {
         let button = UIButton()
         button.setImage(UIImage(named: "ic_camera_20_ios", in: .module, compatibleWith: nil), for: .normal)
         button.backgroundColor = .gray100
-        button.layer.cornerRadius = 24 / 2
+        button.layer.cornerRadius = 16
         button.clipsToBounds = true
         button.layer.shadowColor = UIColor.black.cgColor
         button.layer.shadowOpacity = 0.1

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/String+Markdown.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/String+Markdown.swift
@@ -1,0 +1,37 @@
+//
+//  String+Markdown.swift
+//  HilingualPresentation
+//
+//  Created by 성현주 on 2025/09/17.
+//
+
+import UIKit
+
+extension String {
+    func toMarkdownAttributedString(font: UIFont = .suit(.body_m_16),
+                                     textColor: UIColor = .gray850) -> NSAttributedString {
+        let components = self.components(separatedBy: "\n\n")
+        let result = NSMutableAttributedString()
+
+        for (index, block) in components.enumerated() {
+            if let attr = try? AttributedString(markdown: block, options: .init(interpretedSyntax: .full)) {
+                var mutableAttr = NSMutableAttributedString(attributedString: NSAttributedString(attr))
+                mutableAttr.addAttributes([
+                    .font: font,
+                    .foregroundColor: textColor
+                ], range: NSRange(location: 0, length: mutableAttr.length))
+
+                result.append(mutableAttr)
+            } else {
+                result.append(NSAttributedString(string: block))
+            }
+
+            // 문단 줄바꿈
+            if index < components.count - 1 {
+                result.append(NSAttributedString(string: "\n\n"))
+            }
+        }
+
+        return result
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Login/LoginView.swift
+++ b/HilingualPresentation/Sources/Presentation/Login/LoginView.swift
@@ -26,7 +26,42 @@ final class LoginView: BaseUIView {
         return imageView
     }()
 
-    let appleLoginButton = ASAuthorizationAppleIDButton()
+    let appleLoginButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.backgroundColor = UIColor(named: "gray900") ?? .black
+        button.layer.cornerRadius = 8
+        button.clipsToBounds = true
+
+        let iconImageView = UIImageView()
+        iconImageView.image = UIImage(
+            named: "ic_apple_20_ios",
+            in: .module,
+            compatibleWith: nil
+        )?.withRenderingMode(.alwaysOriginal)
+        iconImageView.contentMode = .scaleAspectFit
+
+        let titleLabel = UILabel()
+        titleLabel.text = "Apple로 계속하기"
+        titleLabel.font = .suit(.body_sb_16)
+        titleLabel.textColor = .white
+        titleLabel.textAlignment = .center
+
+        button.addSubview(iconImageView)
+        button.addSubview(titleLabel)
+
+        iconImageView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(20)
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+
+        return button
+    }()
+
 
     let privacyPolicyButton: UIButton = {
         let button = UIButton(type: .system)
@@ -70,12 +105,12 @@ final class LoginView: BaseUIView {
 
     override func setLayout() {
         logoImageView.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(180)
+            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(252)
             $0.centerX.equalToSuperview()
         }
 
         appleLoginButton.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(120)
+            $0.bottom.equalTo(privacyPolicyButton.snp.top).offset(-16)
             $0.centerX.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.height.equalTo(58)
@@ -87,7 +122,7 @@ final class LoginView: BaseUIView {
         }
 
         privacyPolicyButton.snp.makeConstraints {
-            $0.top.equalTo(appleLoginButton.snp.bottom).offset(16)
+            $0.bottom.equalTo(safeAreaLayoutGuide).inset(16)
             $0.centerX.equalToSuperview()
         }
     }
@@ -109,7 +144,7 @@ extension LoginView {
         // 1
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
             UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseOut], animations: {
-                self.logoImageView.transform = CGAffineTransform(translationX: 0, y: -60)
+                self.logoImageView.transform = CGAffineTransform(translationX: 0, y: -72)
             })
         }
 

--- a/HilingualPresentation/Sources/Presentation/MyPage/BlockUser/BlockUserView.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/BlockUser/BlockUserView.swift
@@ -22,29 +22,58 @@ final class BlockUserView: BaseUIView {
         return tableView
     }()
 
-    let emptyView: EmptyView = {
-        let view = EmptyView()
-        view.isHidden = true
-        view.configure(message: "차단한 유저가 없어요.", imageName: "img_search_ios")
-        return view
+    private let emptyImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "img_search_ios", in: .module, compatibleWith: nil)
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private let messageLabel: UILabel = {
+        let label = UILabel()
+        label.text = "차단된 계정이 없어요."
+        label.font = .suit(.head_m_18)
+        label.textColor = .gray500
+        label.textAlignment = .center
+        return label
+    }()
+
+    private lazy var emptyStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [emptyImageView, messageLabel])
+        stack.axis = .vertical
+        stack.spacing = 8
+        stack.alignment = .center
+        stack.isHidden = true
+        return stack
     }()
 
     // MARK: - UI Setup
 
     override func setUI() {
-        addSubviews(tableView,emptyView)
+        addSubviews(tableView, emptyStackView)
         tableView.refreshControl = refreshControl
     }
 
     override func setLayout() {
         tableView.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide)
-            $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.leading.trailing.bottom.equalToSuperview()
         }
 
-        emptyView.snp.makeConstraints {
-            $0.center.equalToSuperview()
+        emptyStackView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide).offset(140)
+            $0.centerX.equalToSuperview()
         }
+
+        emptyImageView.snp.makeConstraints {
+            $0.width.equalTo(210)
+            $0.height.equalTo(140)
+        }
+    }
+
+    // MARK: - Public Method
+
+    func updateEmptyView(isHidden: Bool) {
+        emptyStackView.isHidden = isHidden
     }
 }

--- a/HilingualPresentation/Sources/Presentation/MyPage/BlockUser/BlockUserViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/BlockUser/BlockUserViewController.swift
@@ -63,7 +63,7 @@ public final class BlockUserViewController: BaseUIViewController<BlockUserViewMo
                 self.blockUserView.refreshControl.endRefreshing()
 
                 let isEmpty = users.isEmpty
-                self.blockUserView.emptyView.isHidden = !isEmpty
+                self.blockUserView.updateEmptyView(isHidden: !isEmpty)
                 self.blockUserView.tableView.isHidden = isEmpty
             }
             .store(in: &cancellables)

--- a/HilingualPresentation/Sources/Presentation/MyPage/BlockUser/BlockedUserCell.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/BlockUser/BlockedUserCell.swift
@@ -26,8 +26,8 @@ final class BlockedUserCell: UITableViewCell {
 
     private let nicknameLabel: UILabel = {
         let label = UILabel()
-        label.font = .suit(.body_b_14)
-        label.textColor = .gray400
+        label.font = .suit(.head_b_16)
+        label.textColor = .black
         label.isUserInteractionEnabled = true
         return label
     }()

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/EditProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/EditProfileView.swift
@@ -36,11 +36,17 @@ final class EditProfileView: BaseUIView {
 
     let withdrawButton: UIButton = {
         let button = UIButton()
-        button.setTitle("회원탈퇴", for: .normal)
-        button.setTitleColor(.gray400, for: .normal)
-        button.titleLabel?.font = .suit(.caption_m_12)
+        let title = "회원탈퇴"
+        let attributes: [NSAttributedString.Key: Any] = [
+            .foregroundColor: UIColor.gray400,
+            .font: UIFont.suit(.body_m_14),
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+        let attributedTitle = NSAttributedString(string: title, attributes: attributes)
+        button.setAttributedTitle(attributedTitle, for: .normal)
         return button
     }()
+
 
     // MARK: - UI Setup
 

--- a/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationCell.swift
+++ b/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationCell.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-import UIKit
-
 final class NotificationCell: UITableViewCell {
 
     static let identifier = "NotificationCell"
@@ -17,7 +15,7 @@ final class NotificationCell: UITableViewCell {
 
     private let messageLabel: UILabel = {
         let label = UILabel()
-        label.font = .suit(.body_sb_14)
+        label.font = .suit(.body_m_16)
         label.textColor = .hilingualBlack
         label.numberOfLines = 2
         return label
@@ -53,7 +51,7 @@ final class NotificationCell: UITableViewCell {
     // MARK: - Configure
 
     func configure(with model: NotificationModel) {
-        messageLabel.text = model.title
+        messageLabel.attributedText = makeBoldUserNameText(from: model.title)
         dateLabel.text = model.publishedAt
         contentView.backgroundColor = model.isRead ? .white : .gray100
     }
@@ -82,5 +80,16 @@ final class NotificationCell: UITableViewCell {
             $0.trailing.equalToSuperview().inset(12)
             $0.size.equalTo(24)
         }
+    }
+
+    // MARK: - Private Methods
+
+    private func makeBoldUserNameText(from text: String) -> NSAttributedString {
+        let attributed = NSMutableAttributedString(string: text)
+        if let range = text.range(of: "이 당신") {
+            let nameRange = NSRange(text.startIndex..<range.lowerBound, in: text)
+            attributed.addAttribute(.font, value: UIFont.suit(.body_sb_16), range: nameRange)
+        }
+        return attributed
     }
 }

--- a/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationCell.swift
+++ b/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationCell.swift
@@ -23,7 +23,7 @@ final class NotificationCell: UITableViewCell {
 
     private let dateLabel: UILabel = {
         let label = UILabel()
-        label.font = .suit(.caption_r_12)
+        label.font = .suit(.caption_r_14)
         label.textColor = .gray300
         return label
     }()

--- a/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationDetail/NotificationDetailModel.swift
+++ b/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationDetail/NotificationDetailModel.swift
@@ -5,11 +5,21 @@
 //  Created by 성현주 on 8/26/25.
 //
 
-
 import Foundation
 
 public struct NotificationDetailModel {
-    let title: String
-    let date: String
-    let content: String
+    public let title: String
+    public let content: String
+
+    private let rawDate: String
+
+    public var date: String {
+        return rawDate.replacingOccurrences(of: "-", with: ".")
+    }
+
+    public init(title: String, date: String, content: String) {
+        self.title = title
+        self.rawDate = date
+        self.content = content
+    }
 }

--- a/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationDetail/NotificationDetailView.swift
+++ b/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationDetail/NotificationDetailView.swift
@@ -32,12 +32,19 @@ final class NotificationDetailView: BaseUIView {
         return view
     }()
 
-    private let contentLabel: UILabel = {
-        let label = UILabel()
-        label.font = .suit(.body_m_16)
-        label.textColor = .gray850
-        label.numberOfLines = 0
-        return label
+    private let contentTextView: UITextView = {
+        let textView = UITextView()
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.dataDetectorTypes = [.link]
+        textView.linkTextAttributes = [
+            .foregroundColor: UIColor.blue,
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+        return textView
     }()
 
     // MARK: - Init
@@ -55,7 +62,7 @@ final class NotificationDetailView: BaseUIView {
     // MARK: - Setup
 
     override func setUI() {
-        addSubviews(titleLabel, dateLabel, contentLabel,separatorView)
+        addSubviews(titleLabel, dateLabel, separatorView, contentTextView)
     }
 
     override func setLayout() {
@@ -70,12 +77,12 @@ final class NotificationDetailView: BaseUIView {
         }
 
         separatorView.snp.makeConstraints {
-              $0.top.equalTo(dateLabel.snp.bottom).offset(16)
-              $0.leading.trailing.equalToSuperview()
-              $0.height.equalTo(1)
-          }
+            $0.top.equalTo(dateLabel.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(1)
+        }
 
-        contentLabel.snp.makeConstraints {
+        contentTextView.snp.makeConstraints {
             $0.top.equalTo(separatorView.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.lessThanOrEqualToSuperview().inset(20)
@@ -87,6 +94,6 @@ final class NotificationDetailView: BaseUIView {
     func configure(with model: NotificationDetailModel) {
         titleLabel.text = model.title
         dateLabel.text = model.date
-        contentLabel.text = model.content
+        contentTextView.attributedText = model.content.toMarkdownAttributedString()
     }
 }

--- a/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationView.swift
+++ b/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationView.swift
@@ -51,14 +51,17 @@ final class NotificationView: BaseUIView {
 
     override func setLayout() {
         tableView.snp.makeConstraints { $0.edges.equalToSuperview() }
-        emptyView.snp.makeConstraints { $0.center.equalToSuperview() }
+        emptyView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview().offset(160)
+        }
     }
 
     // MARK: - Private
 
     private func updateView() {
         let items = notificationListModel.items
-        let message = "아직 알림이 없어요"
+        let message = "아직 알림이 없어요."
         emptyView.configure(message: message)
 
         tableView.isHidden = items.isEmpty

--- a/HilingualPresentation/Sources/Presentation/OnBoarding/LaunchScreen.swift
+++ b/HilingualPresentation/Sources/Presentation/OnBoarding/LaunchScreen.swift
@@ -38,7 +38,7 @@ extension LaunchScreen {
 
     private func setLayout() {
         logoImageView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(180)
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(252)
             $0.centerX.equalToSuperview()
         }
     }

--- a/HilingualPresentation/Sources/Presentation/Splash/SplashView.swift
+++ b/HilingualPresentation/Sources/Presentation/Splash/SplashView.swift
@@ -28,7 +28,7 @@ final class SplashView: BaseUIView {
 
     override func setLayout() {
         logoImageView.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(180)
+            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(252)
             $0.centerX.equalToSuperview()
         }
     }

--- a/HilingualPresentation/Sources/Presentation/WordBook/Modal/WordDetailDialog.swift
+++ b/HilingualPresentation/Sources/Presentation/WordBook/Modal/WordDetailDialog.swift
@@ -42,7 +42,7 @@ final class WordDetailDialog: UIView {
     // MARK: - Setup
 
     private func setStyle() {
-        backgroundColor = .dim
+        backgroundColor = .dim2
         self.isHidden = true
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(dismiss(_:)))

--- a/HilingualPresentation/Sources/Presentation/WordBook/TableView/WordBookHeaderView.swift
+++ b/HilingualPresentation/Sources/Presentation/WordBook/TableView/WordBookHeaderView.swift
@@ -34,12 +34,28 @@ final class WordBookHeaderView: UITableViewHeaderFooterView {
         titleLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(16)
             $0.bottom.equalToSuperview().inset(8)
-            $0.top.equalToSuperview().offset(12)  
+            $0.top.equalToSuperview().offset(12)
         }
     }
-    
+
     func configure(title: String) {
-        titleLabel.text = title.uppercased()
-        titleLabel.attributedText = .suit(.body_sb_16, text: title.uppercased())
+        let translated = translateHeaderTitle(title)
+        titleLabel.attributedText = .suit(.body_sb_16, text: translated)
+    }
+
+    private func translateHeaderTitle(_ key: String) -> String {
+        if key == "today" {
+            return "오늘"
+        } else if key == "yesterday" {
+            return "어제"
+        } else if key.hasSuffix("days") {
+            let num = key.replacingOccurrences(of: "days", with: "")
+            return "\(num)일 전"
+        } else if key.hasSuffix("day") {
+            let num = key.replacingOccurrences(of: "day", with: "")
+            return "\(num)일 전"
+        } else {
+            return key
+        }
     }
 }

--- a/HilingualPresentation/Sources/Presentation/WordBook/WordBookEmptyView.swift
+++ b/HilingualPresentation/Sources/Presentation/WordBook/WordBookEmptyView.swift
@@ -95,7 +95,7 @@ final class WordBookEmptyView: UIView {
         case .noSearchResult:
             emptyImageView.image = UIImage(named: "img_search_ios", in: .module, compatibleWith: nil)
             emptyImageView.isHidden = false
-            emptyLabel.text = "검색 결과가 없습니다."
+            emptyLabel.text = "검색 결과가 없어요."
             emptyButton.isHidden = true
         }
     }

--- a/HilingualPresentation/Sources/Presentation/WordBook/WordBookViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/WordBook/WordBookViewController.swift
@@ -18,6 +18,7 @@ public final class WordBookViewController: BaseUIViewController<WordBookViewMode
     private var filteredWordList: [(String, [PhraseData])] = []
 
     private var selectedSortIndex: Int = 0
+    private var isSearching: Bool = false
 
     // MARK: - Inputs
 
@@ -158,7 +159,8 @@ public final class WordBookViewController: BaseUIViewController<WordBookViewMode
     }
 
     private func filterWords(for keyword: String) {
-        let isSearching = !keyword.isEmpty
+        isSearching = !keyword.isEmpty 
+
         wordBookView.showHeaderView(!isSearching)
         wordBookView.tableView.contentInset.top = isSearching ? 16 : 0
 
@@ -169,21 +171,28 @@ public final class WordBookViewController: BaseUIViewController<WordBookViewMode
             return
         }
 
-        filteredWordList = fullWordList.compactMap { (date, items) in
-            let filtered = items.filter {
-                $0.phrase.lowercased().contains(keyword.lowercased())
-            }
-            return filtered.isEmpty ? nil : (date, filtered)
+        let flattenedItems = fullWordList.flatMap { $0.1 }
+        let filtered = flattenedItems.filter {
+            $0.phrase.lowercased().contains(keyword.lowercased())
         }
+        let sorted = filtered.sorted { $0.phrase.lowercased() < $1.phrase.lowercased() }
+        filteredWordList = sorted.isEmpty ? [] : [("", sorted)]
 
         wordBookView.tableView.reloadData()
         updateViewState()
     }
 
-    //MARK: - Action Method
+    // MARK: - Action Method
 
     @objc
     private func didPullToRefresh() {
+        guard !isSearching else {
+            DispatchQueue.main.async { [weak self] in
+                self?.wordBookView.refreshControl.endRefreshing()
+            }
+            return
+        }
+
         refreshSubject.send(())
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
             self?.wordBookView.refreshControl.endRefreshing()
@@ -236,7 +245,6 @@ extension WordBookViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let isSearching = !(wordBookView.searchBar.text ?? "").isEmpty
         if isSearching { return nil }
 
         guard let header = tableView.dequeueReusableHeaderFooterView(
@@ -249,17 +257,15 @@ extension WordBookViewController: UITableViewDataSource, UITableViewDelegate {
         return header
     }
 
+    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return isSearching ? CGFloat.leastNonzeroMagnitude : UITableView.automaticDimension
+    }
+
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let item = filteredWordList[indexPath.section].1[indexPath.row]
         selectedWordIdSubject.send(Int(item.phraseId))
     }
-
-    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        let isSearching = !(wordBookView.searchBar.text ?? "").isEmpty
-        return isSearching ? 0 : UITableView.automaticDimension
-    }
 }
-
 
 // MARK: - UISearchBarDelegate
 
@@ -268,6 +274,8 @@ extension WordBookViewController: UISearchBarDelegate {
         filterWords(for: searchText)
     }
 }
+
+// MARK: - UITextFieldDelegate
 
 extension WordBookViewController: UITextFieldDelegate {
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
@@ -289,5 +297,4 @@ extension WordBookViewController: UITextFieldDelegate {
         textField.resignFirstResponder()
         return true
     }
-
 }


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #이슈번호

---

## 📎 Work Description 
- 공지사항 상세보기, 마크다운 문법 파싱로직 구현
```swift
import UIKit

extension String {
    func toMarkdownAttributedString(font: UIFont = .suit(.body_m_16),
                                     textColor: UIColor = .gray850) -> NSAttributedString {
        let components = self.components(separatedBy: "\n\n")
        let result = NSMutableAttributedString()

        for (index, block) in components.enumerated() {
            if let attr = try? AttributedString(markdown: block, options: .init(interpretedSyntax: .full)) {
                var mutableAttr = NSMutableAttributedString(attributedString: NSAttributedString(attr))
                mutableAttr.addAttributes([
                    .font: font,
                    .foregroundColor: textColor
                ], range: NSRange(location: 0, length: mutableAttr.length))

                result.append(mutableAttr)
            } else {
                result.append(NSAttributedString(string: block))
            }

            // 문단 줄바꿈
            if index < components.count - 1 {
                result.append(NSAttributedString(string: "\n\n"))
            }
        }

        return result
    }
}
```
라이브러리에 의존하지 않고 마크다운을 구현하기 위해 찾아본 결과 마크다운 파서(AttributedString(markdown:))는 "string\n\n[링크](url)" 형식에서 첫 문단이 짧을 경우, 줄바꿈을 무시하거나 링크와 한 줄로 이어 붙이는 문제가 있어서 줄바꿈이 정상적으로 안되는 문제가있었는데 특히 Swift의 AttributedString은 HTML처럼 <p>를 생성하지 않고, 단순히 NSParagraphStyle 기반으로 조절하기 때문에 발생한다고 하더라구요 그래서 마크다운 블록을 문단별로 나눠 NSAttributedString으로 직접 합치는 방식으로 구현했습니다

- 차단유저없음뷰 레이아웃 조정
- 알림 디테일 날짜 포멧팅 변경  => 전 이건 model에 책임을 위임했는데, 뷰모델에서 포멧팅하는게 좋을까요 모델에서하는게 좋을까요?
- 단어장 검색결과없을때 라이팅 변경했습니다
- 회원탈퇴 밑줄, 폰트 수정했습니다
- 알림 엠티뷰에 온점 추가와 높이를 조정했습니다
- 차단 유저 닉네임 색 변경하고, 폰트 변경했씁니다
- 알림 닉네임을 볼드 처리했습니다
- 서버로부터 오는 영어날짜를 한국어로 변환하는 로직을 구현했습니다
- 알림 닉네임을 볼드처림했습니다 => "이 당신"이걸로 구별할수 잇도록 했습니다 닉네임에 띄어쓰기가 없어서 괜찮을거라 판단했습니다
- 단어장 상세보기 배경색을 dim2로 변경했습니다
- 단어장 검색시 간격을 유지하고,새로운 이슈였던 단어장 검색중에 새로고침되는 문제를 해결했습니다 => 기존에 그룹단위로 테이블뷰에서 처리하다보니 서버로부터 오는 그룹을 평탄화해주는 flatmap으로 변경후 구현했습니다
- 애플로그인을 커스텀 버튼으로 변경했습니다


---
<img width="250" height="2622" alt="simulator_screenshot_0B6F568C-F169-4272-AF3F-DD1E3B5AFCA5" src="https://github.com/user-attachments/assets/d275a84e-f492-4394-a0f4-af62df1c8c43" />
|<img width="250" height="2622" alt="simulator_screenshot_4BC53A98-F13B-4202-9FA8-0764A7278CBC" src="https://github.com/user-attachments/assets/0f8f56e3-e0d0-4523-9809-317c89a9b78c" />







## 📷 Screenshots  

| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/23e4284b-522e-45ba-82cb-4e52c28daf53" width="250"> | <img src="simulator_screenshot_0B6F568C-F169-4272-AF3F-DD1E3B5AFCA5" src="https://github.com/user-attachments/assets/d275a84e-f492-4394-a0f4-af62df1c8c43" width="250"> |
| B 기능 | <img src="simulator_screenshot_4BC53A98-F13B-4202-9FA8-0764A7278CBC" src="https://github.com/user-attachments/assets/0f8f56e3-e0d0-4523-9809-317c89a9b78c" width="250"> | <img src="https://github.com/user-attachments/assets/d6af4aa7-f04e-405f-956f-f2cd65db89e7" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |


---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
