### PR TITLE
[refactor] 리퀴드 글라스 대응 + 피드 api 중복 호출 문제 해결

### DIFF
--- a/HilingualNetwork/Sources/HilingualNetwork/Foundation/AuthInterceptor.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/Foundation/AuthInterceptor.swift
@@ -14,9 +14,13 @@ public final class AuthInterceptor: RequestInterceptor {
     public static let shared = AuthInterceptor()
     private init() {}
 
+    // MARK: - Properties
     private var cancellables = Set<AnyCancellable>()
+    private var isRefreshing = false
+    private var requestsToRetry: [(RetryResult) -> Void] = []
 
     // MARK: - 요청 시 토큰 헤더 주입
+    
     public func adapt(_ urlRequest: URLRequest,
                       for session: Session,
                       completion: @escaping (Result<URLRequest, Error>) -> Void) {
@@ -37,6 +41,7 @@ public final class AuthInterceptor: RequestInterceptor {
     }
 
     // MARK: - 401 발생 시 토큰 재발급 후 재시도
+
     public func retry(_ request: Request,
                       for session: Session,
                       dueTo error: Error,
@@ -49,35 +54,56 @@ public final class AuthInterceptor: RequestInterceptor {
 
         print("[AuthInterceptor] 🔄 401 감지 → 토큰 리프레시 시도")
 
+        requestsToRetry.append(completion)
+
+        guard !isRefreshing else { return }
+        isRefreshing = true
+
         let refreshToken = UserDefaultHandler.refreshToken
         if refreshToken.isEmpty {
+            completeAllWithFailure(NetworkError.refreshFailed)
             notifySessionExpired()
-            completion(.doNotRetryWithError(NetworkError.refreshFailed))
             return
         }
 
-        let authService = DefaultAuthService()
-        authService.refreshToken(token: refreshToken)
+        DefaultAuthService().refreshToken(token: refreshToken)
             .sink { [weak self] result in
                 switch result {
                 case .failure(let err):
                     print("[AuthInterceptor] ❌ 토큰 재발급 실패: \(err)")
+                    self?.completeAllWithFailure(err)
                     self?.notifySessionExpired()
-                    completion(.doNotRetryWithError(err))
                 case .finished:
                     break
                 }
-            } receiveValue: { dto in
+            } receiveValue: { [weak self] dto in
+                guard let self else { return }
                 UserDefaultHandler.accessToken = dto.accessToken
                 UserDefaultHandler.refreshToken = dto.refreshToken
                 print("[AuthInterceptor] ✅ 토큰 재발급 성공 → 요청 재시도")
-                completion(.retry)
+                self.completeAllWithRetry()
             }
             .store(in: &cancellables)
     }
 
+    // MARK: - Pending 요청 처리
+
+    private func completeAllWithRetry() {
+        isRefreshing = false
+        let completions = requestsToRetry
+        requestsToRetry.removeAll()
+        completions.forEach { $0(.retry) }
+    }
+
+    private func completeAllWithFailure(_ error: Error) {
+        isRefreshing = false
+        let completions = requestsToRetry
+        requestsToRetry.removeAll()
+        completions.forEach { $0(.doNotRetryWithError(error)) }
+    }
+
     // MARK: - 세션 만료 이벤트 발행
-    
+
     private func notifySessionExpired() {
         NotificationCenter.default.post(
             name: Notification.Name("SessionExpired"),

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/BaseUIViewController+Navigation.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/BaseUIViewController+Navigation.swift
@@ -92,9 +92,9 @@ public extension BaseUIViewController {
         button.setImage(image, for: .normal)
         button.tintColor = .black
         button.addTarget(self, action: action, for: .touchUpInside)
-        button.frame = CGRect(x: 0, y: 0, width: 24, height: 24)
-        button.contentHorizontalAlignment = .fill
-        button.contentVerticalAlignment = .fill
+//        button.frame = CGRect(x: 0, y: 0, width: 24, height: 24)
+//        button.contentHorizontalAlignment = .fill
+//        button.contentVerticalAlignment = .fill
 
         return UIBarButtonItem(customView: button)
     }

--- a/HilingualPresentation/Sources/Presentation/Feed/FeedViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Feed/FeedViewController.swift
@@ -82,11 +82,14 @@ public final class FeedViewController: BaseUIViewController<FeedViewModel> {
         navigationController?.setNavigationBarHidden(true, animated: false)
         
         input.reload.send()
-                
+    }
+
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         recommendFeedVC.refresh()
         followingFeedVC.refresh()
     }
-    
+
     // MARK: - Binding
     
     public override func bind(viewModel: FeedViewModel) {
@@ -98,13 +101,6 @@ public final class FeedViewController: BaseUIViewController<FeedViewModel> {
                 self?.feedView.updateProfileImage(url)
             }
             .store(in: &viewModel.cancellables)
-    }
-    
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        recommendFeedVC.refresh()
-        followingFeedVC.refresh()
     }
 
     //MARK: - Action


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #324 

---

## 📎 Work Description 
- 갑자기 적용된 리퀴드 글라스에 맞춰 대응했습니다
- 중복으로호출되는 홈 api를 제거했습니다
- 여러 Api가 동시에 호출되는 경우 인터셉터가 한 api만 처리해서 발생하는 에러를 처리했습니다
기존 코드: 401 요청마다 refreshToken 호출 → 동시에 여러 번 호출 → 토큰 꼬임 발생, 일부 요청 실패 → 세션 만료 잘못 감지 → 홈 → 스플래시 튕김 현상.
개선된 코드: refresh 요청을 싱글턴으로 보장 + 큐 처리 → 토큰 발급 과정이 안전해지고, 동시에 들어온 요청들도 정상적으로 재시도 가능.

---

## 📷 Screenshot
<img width="688" height="704" alt="스크린샷 2025-09-17 오후 11 53 15" src="https://github.com/user-attachments/assets/579cd5e7-8567-41a1-a431-616688ea6686" />


| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/87045564-f9f1-452c-ab92-23f4fde299e3" width="250"> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
