### PR TITLE
[fix] API 3번 호출 이슈 해결

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/SegmentedControl.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/SegmentedControl.swift
@@ -19,7 +19,7 @@ final class SegmentedControl: UIView {
     var onIndexChanged: ((Int) -> Void)?
     
     // 현재 선택된 인덱스
-    var selectedIndex: Int {
+    var setSelectedIndexWithAPI: Int {
         get { segmentedControl.selectedIndex }
         set { segmentedControl.selectedIndex = newValue }
     }

--- a/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
@@ -40,6 +40,16 @@ public final class DiaryWritingViewController: BaseUIViewController<DiaryWriting
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(false, animated: false)
+
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+        navigationController?.interactivePopGestureRecognizer?.delegate = nil
     }
 
     public init(

--- a/HilingualPresentation/Sources/Presentation/Feed/FeedView.swift
+++ b/HilingualPresentation/Sources/Presentation/Feed/FeedView.swift
@@ -190,8 +190,17 @@ final class FeedView: BaseUIView {
     }
     
     func setSelectedIndex(_ index: Int) {
-        segmentedControl?.selectedIndex = index
+        segmentedControl?.setSelectedIndexWithAPI = index
         onSegmentChanged?(index)
+    }
+    
+    func setSelectedIndexUIOnly(_ index: Int) {
+        guard let control = segmentedControl else { return }
+        
+        let original = control.onIndexChanged
+        control.onIndexChanged = nil
+        control.setSelectedIndexWithAPI = index
+        control.onIndexChanged = original
     }
 
     //MARK: - Actions

--- a/HilingualPresentation/Sources/Presentation/Feed/FeedViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Feed/FeedViewController.swift
@@ -80,7 +80,6 @@ public final class FeedViewController: BaseUIViewController<FeedViewModel> {
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
-        
         input.reload.send()
     }
 
@@ -228,14 +227,14 @@ extension FeedViewController {
     
     public func handleFeedTabSelected(isReSelected: Bool) {
         if isReSelected {
-            if feedView.segmentedControl?.selectedIndex == 0 {
+            if feedView.segmentedControl?.setSelectedIndexWithAPI == 0 {
                 resetRecommendFeed()
             } else {
                 resetFollowingFeed()
             }
         } else {
-            feedView.segmentedControl?.selectedIndex = 0
-            resetRecommendFeed()
+            feedView.setSelectedIndexUIOnly(0)
+            recommendFeedVC.resetScrollPosition()
         }
     }
 }

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
@@ -147,7 +147,7 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
     }
     
     public func refresh() {
-        input.reload.send(())
+        input.reloadFeeds.send(())
     }
     
     // MARK: - Actions
@@ -157,7 +157,7 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
     }
     
     @objc private func didTopScrollRefresh() {
-        self.input.reload.send(())
+        self.input.reloadFeeds.send(())
         feedCellView.tableView.refreshControl?.endRefreshing()
     }
     

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewController.swift
@@ -49,7 +49,6 @@ public final class FeedProfileViewController: BaseUIViewController<FeedProfileVi
     public override func viewDidLoad() {
         super.viewDidLoad()
         bindViewModel()
-        input.reload.send(())
         
         view.addSubview(feedCellView)
         feedCellView.snp.makeConstraints { $0.edges.equalToSuperview() }

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewModel.swift
@@ -14,7 +14,8 @@ public final class FeedProfileViewModel: BaseViewModel, BaseViewModelType {
     // MARK: - Input/Output
     
     public struct Input {
-        let reload = PassthroughSubject<Void, Never>()
+        let reloadProfile = PassthroughSubject<Void, Never>()
+        let reloadFeeds = PassthroughSubject<Void, Never>()
         let follow = PassthroughSubject<Void, Never>()
         let unfollow = PassthroughSubject<Void, Never>()
         let block = PassthroughSubject<Void, Never>()
@@ -82,9 +83,8 @@ public final class FeedProfileViewModel: BaseViewModel, BaseViewModelType {
     // MARK: - Transform
     
     public func transform(input: Input) -> Output {
-        let trigger = input.reload.eraseToAnyPublisher()
-        
-        trigger
+        /// 프로필
+        input.reloadProfile
             .flatMap { [weak self] _ -> AnyPublisher<FeedProfileInfoEntity?, Never> in
                 guard let self else { return Just(nil).eraseToAnyPublisher() }
                 return self.profileInfoUseCase.execute(targetUserId: self.targetUserId)
@@ -104,7 +104,8 @@ public final class FeedProfileViewModel: BaseViewModel, BaseViewModelType {
             }
             .store(in: &cancellables)
         
-        trigger
+        /// 피드
+        input.reloadFeeds
             .flatMap { [weak self] _ -> AnyPublisher<[FeedModel], Never> in
                 guard let self else { return Just([]).eraseToAnyPublisher() }
                 self.isLoadingSubject.send(true)

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/FeedProfileViewModel.swift
@@ -82,8 +82,7 @@ public final class FeedProfileViewModel: BaseViewModel, BaseViewModelType {
     // MARK: - Transform
     
     public func transform(input: Input) -> Output {
-        let trigger = Publishers.Merge(viewDidLoad, input.reload.eraseToAnyPublisher())
-            .eraseToAnyPublisher()
+        let trigger = input.reload.eraseToAnyPublisher()
         
         trigger
             .flatMap { [weak self] _ -> AnyPublisher<FeedProfileInfoEntity?, Never> in

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileView.swift
@@ -15,7 +15,7 @@ final class MyFeedProfileView: BaseUIView {
     // MARK: - UI Components
     
     private let myFeedView = FeedUserProfile()
-    private var segmentedControl: SegmentedControl?
+    private(set) var segmentedControl: SegmentedControl?
     private var segmentedTopConstraint: Constraint?
     
     // MARK: - Setup

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileView.swift
@@ -74,7 +74,7 @@ final class MyFeedProfileView: BaseUIView {
     }
     
     func setSelectedIndex(_ index: Int) {
-        segmentedControl?.selectedIndex = index
+        segmentedControl?.setSelectedIndexWithAPI = index
         onSegmentChanged?(index)
     }
 

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileViewController.swift
@@ -114,12 +114,12 @@ public final class MyFeedProfileViewController: BaseUIViewController<FeedProfile
         input.reload.send(())
     }
     
-//    public override func viewDidAppear(_ animated: Bool) {
-//        super.viewDidAppear(animated)
-//        
-//        sharedVC.refresh()
-//        likedVC.refresh()
-//    }
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        sharedVC.refresh()
+        likedVC.refresh()
+    }
     
     // MARK: - Bind
     

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileViewController.swift
@@ -126,7 +126,6 @@ public final class MyFeedProfileViewController: BaseUIViewController<FeedProfile
     // MARK: - Bind
     
     private func bind() {
-        let input = FeedProfileViewModel.Input()
         guard let viewModel else { return }
 
         let output = viewModel.transform(input: input)

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileViewController.swift
@@ -111,7 +111,7 @@ public final class MyFeedProfileViewController: BaseUIViewController<FeedProfile
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(false, animated: false)
-        input.reload.send(())
+        input.reloadProfile.send(())
     }
     
     public override func viewDidAppear(_ animated: Bool) {

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/MyFeed/MyFeedProfileViewController.swift
@@ -102,8 +102,6 @@ public final class MyFeedProfileViewController: BaseUIViewController<FeedProfile
         myFeedProfileView.setFollowSectionTappedAction { [weak self] in
             self?.pushFollowListViewController()
         }
-
-        bind()
     }
     
     public override func navigationType() -> NavigationType? {
@@ -116,18 +114,17 @@ public final class MyFeedProfileViewController: BaseUIViewController<FeedProfile
         input.reload.send(())
     }
     
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        sharedVC.refresh()
-        likedVC.refresh()
-    }
+//    public override func viewDidAppear(_ animated: Bool) {
+//        super.viewDidAppear(animated)
+//        
+//        sharedVC.refresh()
+//        likedVC.refresh()
+//    }
     
     // MARK: - Bind
     
-    private func bind() {
-        guard let viewModel else { return }
-
+    public override func bind(viewModel: FeedProfileViewModel) {
+        let input = FeedProfileViewModel.Input()
         let output = viewModel.transform(input: input)
 
         output.profile

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/UserFeed/UserFeedViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/UserFeed/UserFeedViewController.swift
@@ -51,7 +51,7 @@ public final class UserFeedProfileViewController: BaseUIViewController<FeedProfi
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(false, animated: false)
 
-        input.reload.send(())
+        input.reloadProfile.send(())
 
         sharedVC.refresh()
     }

--- a/HilingualPresentation/Sources/Presentation/FeedProfile/UserFeed/UserFeedViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/FeedProfile/UserFeed/UserFeedViewController.swift
@@ -50,6 +50,10 @@ public final class UserFeedProfileViewController: BaseUIViewController<FeedProfi
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(false, animated: false)
+
+        input.reload.send(())
+
+        sharedVC.refresh()
     }
     
     public override func viewDidLoad() {
@@ -130,7 +134,6 @@ public final class UserFeedProfileViewController: BaseUIViewController<FeedProfi
                 break
             }
         }
-        
         bind()
     }
     
@@ -193,8 +196,6 @@ public final class UserFeedProfileViewController: BaseUIViewController<FeedProfi
                 self?.userFeedProfileView.followButtonState(state)
             }
             .store(in: &cancellables)
-
-        self.input.reload.send(())
     }
         
     // MARK: - Private Methods


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #327 

---

## 📎 Work Description 
### 해결한 이슈
- 타인 피드 프로필
  - 프로필 정보 API, 공유 피드 API가 각각 2번씩 호출되는 문제
- 마이 피드 프로필
  - 프로필 정보 API가 3번, 공유/공감 피드 API가 각각 2번씩 호출되는 문제

### 원인
- `FeedProfileViewModel`에서 `reload` 트리거가 프로필 정보 API와 피드 리스트 API 모두 실행하도록 묶여 있었음
- 각 화면에서 `reload.send(())` 호출 시 두 API가 동시에 호출되어 중복 요청 발생 ㅠ
- `UserFeedProfileViewController`, `MyFeedProfileViewController` 내부에서 `input.reload.send(())`와 `sharedVC.refresh()`를 함께 호출하여 중복됨!!

### 해결 방법
1. ViewModel Input 분리
   - 기존 `reload` → `reloadProfile`, `reloadFeeds`로 분리
   - `reloadProfile`: 프로필 정보 API 전용
   - `reloadFeeds`: 피드 리스트 API 전용

2. 컨트롤러 호출 정리
   - 프로필: `input.reloadProfile.send(())`
   - 피드: `sharedVC.refresh()` → 내부에서 `input.reloadFeeds.send(())` 호출
   - 각 API가 명확하게 한 번만 호출되도록 변경


---

## 📷 Screenshots  

| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| A 기능 | <img src="" width="250"> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |

---

## 💬 To Reviewers  
- 좋은 방법은 아닌 것 같은데... 나중에 거하게 리펙 들어갈게요 ㅠ 아 너무 어렵다 

+ 스와이프 코드 한번 더 확인하길... 시뮬에서 확인못해요
