### PR TITLE
[fix] 마크다운 파서 수정 + 스크롤뷰 추가

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/String+Markdown.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/String+Markdown.swift
@@ -8,30 +8,94 @@
 import UIKit
 
 extension String {
-    func toMarkdownAttributedString(font: UIFont = .pretendard(.body_r_16),
-                                     textColor: UIColor = .gray850) -> NSAttributedString {
-        let components = self.components(separatedBy: "\n\n")
+    func toMarkdownAttributedString(
+        font: UIFont = .pretendard(.body_r_16),
+        textColor: UIColor = .gray850
+    ) -> NSAttributedString {
+        let paragraphs = components(separatedBy: "\n\n")
         let result = NSMutableAttributedString()
 
-        for (index, block) in components.enumerated() {
-            if let attr = try? AttributedString(markdown: block, options: .init(interpretedSyntax: .full)) {
-                var mutableAttr = NSMutableAttributedString(attributedString: NSAttributedString(attr))
-                mutableAttr.addAttributes([
-                    .font: font,
-                    .foregroundColor: textColor
-                ], range: NSRange(location: 0, length: mutableAttr.length))
+        for (index, paragraph) in paragraphs.enumerated() {
+            let processedParagraph = escapeNumberedList(in: paragraph)
+            let markdownParagraph = convertLineBreaks(in: processedParagraph)
 
-                result.append(mutableAttr)
+            if let attributedString = parseMarkdown(markdownParagraph, font: font, textColor: textColor) {
+                result.append(attributedString)
             } else {
-                result.append(NSAttributedString(string: block))
+                result.append(createPlainText(paragraph, font: font, textColor: textColor))
             }
 
-            // 문단 줄바꿈
-            if index < components.count - 1 {
+            if index < paragraphs.count - 1 {
                 result.append(NSAttributedString(string: "\n\n"))
             }
         }
 
         return result
+    }
+
+    private func escapeNumberedList(in text: String) -> String {
+        let pattern = "^(\\d+)\\. "
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .anchorsMatchLines) else {
+            return text
+        }
+
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.stringByReplacingMatches(
+            in: text,
+            options: [],
+            range: range,
+            withTemplate: "$1\\\\. "
+        )
+    }
+
+    private func convertLineBreaks(in text: String) -> String {
+        text.replacingOccurrences(of: "\n", with: "  \n")
+    }
+
+    private func parseMarkdown(
+        _ text: String,
+        font: UIFont,
+        textColor: UIColor
+    ) -> NSAttributedString? {
+        guard let attributedString = try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .full)
+        ) else {
+            return nil
+        }
+
+        let mutableAttributedString = NSMutableAttributedString(attributedString: NSAttributedString(attributedString))
+        let paragraphStyle = createParagraphStyle()
+
+        mutableAttributedString.addAttributes(
+            [
+                .font: font,
+                .foregroundColor: textColor,
+                .paragraphStyle: paragraphStyle
+            ],
+            range: NSRange(location: 0, length: mutableAttributedString.length)
+        )
+
+        return mutableAttributedString
+    }
+
+    private func createParagraphStyle() -> NSParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = 4
+        return style
+    }
+
+    private func createPlainText(
+        _ text: String,
+        font: UIFont,
+        textColor: UIColor
+    ) -> NSAttributedString {
+        NSAttributedString(
+            string: text,
+            attributes: [
+                .font: font,
+                .foregroundColor: textColor
+            ]
+        )
     }
 }

--- a/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationDetail/NotificationDetailView.swift
+++ b/HilingualPresentation/Sources/Presentation/NotificationHome/NotificationDetail/NotificationDetailView.swift
@@ -11,6 +11,18 @@ final class NotificationDetailView: BaseUIView {
 
     // MARK: - UI Components
 
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = true
+        scrollView.alwaysBounceVertical = true
+        return scrollView
+    }()
+
+    private let contentView: UIView = {
+        let view = UIView()
+        return view
+    }()
+
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = .pretendard(.head_sb_20)
@@ -62,12 +74,23 @@ final class NotificationDetailView: BaseUIView {
     // MARK: - Setup
 
     override func setUI() {
-        addSubviews(titleLabel, dateLabel, separatorView, contentTextView)
+        addSubview(scrollView)
+        scrollView.addSubview(contentView)
+        contentView.addSubviews(titleLabel, dateLabel, separatorView, contentTextView)
     }
 
     override func setLayout() {
+        scrollView.snp.makeConstraints {
+            $0.edges.equalTo(safeAreaLayoutGuide)
+        }
+
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalToSuperview()
+        }
+
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide).inset(16)
+            $0.top.equalToSuperview().inset(16)
             $0.leading.trailing.equalToSuperview().inset(20)
         }
 
@@ -85,7 +108,7 @@ final class NotificationDetailView: BaseUIView {
         contentTextView.snp.makeConstraints {
             $0.top.equalTo(separatorView.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.bottom.lessThanOrEqualToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(20)
         }
     }
 


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #356 

---

## 📎 Work Description 
- 마크 다운 파서를 수정해서 기존에 발생하던 줄바꿈 오류를 해결했습니다
## 로직 설명

### 전체 처리 흐름

저희가 발생했던 문제는 \n\n인 줄바꿈을 인식을 못하고 무시한다는게 문제였는데요.
swift,uikit에서 공식적으로 지원하는 마크다운 파서가 없다보니 수동을 파서를 만들어줘야했는데, \n과 \n\n을 구분하는게 쉽지 않아서 고민하다가 \n\n은 별도로 분리하고자 했습니다

그래서 서버로 부터 전달된 텍스트는 먼저 `\n\n` (연속된 두 개의 줄바꿈)을 기준으로 문단 단위로 분리해요. 이렇게 분리하는 이유는 각 문단을 독립적으로 처리하고, 문단 사이의 간격을 명시적으로 제어해서 앞서 발생했던 씹히는 문제를 해결하고자 했어요

분리된 각 문단은 순차적으로 세 가지 변환 과정을 거칩니다. 
첫 번째로 숫자 리스트 이스케이프 처리가 진행됩니다. 마크다운 파서는 `1. 항목` 형태의 텍스트를 자동으로 ordered list로 변환하려고 시도하는데, 서버에서 내려오는 넘버링을 그대로 유지하기 위해 정규식을 사용하여 `1\. 항목` 형태로 변환합니다. 정규식 패턴 `^(\d+)\. `은 줄 시작 부분의 "숫자 + 점 + 공백" 형태를 탐지하고, `anchorsMatchLines` 옵션을 통해 여러 줄에서 모두 적용할수 있도록 했어요

두 번째로 줄바꿈 변환이 이루어집니다. 마크다운에서는 단순한 `\n`을 공백으로 처리하기 때문에, 실제 줄바꿈을 표현하려면 줄 끝에 공백 2개와 줄바꿈 문자가 필요합니다. 따라서 모든 `\n`을 `  \n` (공백 2개 + 줄바꿈) 형태로 변환하여 마크다운 파서가 줄바꿈을 올바르게 인식하도록 했습니다.

세 번째로 변환된 텍스트를 `AttributedString(markdown:)` API를 사용하여 마크다운 파싱을 시도합니다. 파싱에 성공하면 볼드, 링크 등의 마크다운 문법이 적용된 AttributedString이 생성되고, 여기에 기본 폰트, 텍스트 컬러, 그리고 `lineSpacing: 4`가 설정된 문단 스타일을 추가로 적용합니다. 만약 파싱에 실패하면 일반 텍스트로 폴백하여 기본 스타일만 적용한 NSAttributedString을 생성합니다.

마지막으로 처리된 각 문단을 하나의 NSMutableAttributedString에 순차적으로 추가하며, 문단과 문단 사이에는 `\n\n`을 명시적으로 삽입하여 문단 간격을 만들어냅니다. 이렇게 완성된 NSAttributedString이 최종적으로 반환되어 UITextView에 표시할수 있도록 했서요

### 핵심 포인트

- 문단 단위 분리를 통해 문단 간격을 명확하게 제어할수 있도록 했고,
- 정규식을 통한 숫자 리스트 이스케이프로 서버 넘버링 유지할려고 했어요. 정규식을 사용하는게 최선인가 싶지만,,, 생각이 안나서 정규식으로 예외처리 해줬습니다

---

## 📷 Screenshots  
![Simulator Screen Recording - iPhone 17 Pro - 2025-12-14 at 23 35 12](https://github.com/user-attachments/assets/bb4b5399-d5b6-4b36-87c1-8447b614dc0f)

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
