### PR TITLE
[chore] EmptyView configure에 font 파라미터 추가

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/EmptyView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/EmptyView.swift
@@ -14,7 +14,6 @@ final class EmptyView: UIView {
     
     private let messageLabel: UILabel = {
         let label = UILabel()
-        label.font = .pretendard(.head_r_18)
         label.textColor = .gray500
         label.textAlignment = .center
         label.numberOfLines = 2
@@ -80,9 +79,11 @@ final class EmptyView: UIView {
     
     func configure(
         message: String,
-        imageName: String? = nil
+        imageName: String? = nil,
+        font: UIFont = .pretendard(.head_r_18)
     ) {
         messageLabel.text = message
+        messageLabel.font = font
         
         if let imageName {
             imageView.image = UIImage(

--- a/HilingualPresentation/Sources/Presentation/Common/Components/Home/SelectedInfo.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Home/SelectedInfo.swift
@@ -33,7 +33,8 @@ final class SelectedInfo: UIView {
         let view = EmptyView()
         view.configure(
             message: "작성된 일기가 없어요.\n좋은 하루 보내셨기를 바라요!",
-            imageName: "img_diary_empty_ios"
+            imageName: "img_diary_empty_ios",
+            font: .pretendard(.body_m_14)
         )
         return view
     }()
@@ -42,7 +43,8 @@ final class SelectedInfo: UIView {
         let view = EmptyView()
         view.configure(
             message: "아직 작성 가능한 시간이 아니에요.\n오늘의 일기를 작성해주세요!",
-            imageName: "img_diary_lock_ios"
+            imageName: "img_diary_lock_ios",
+            font: .pretendard(.body_m_14)
         )
         return view
     }()


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [x] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #388 

---

## 📎 Work Description 
- EmptyView 컴포넌트를 통일하는 과정에서 폰트 분리를 고려하지 못했습니다... 
홈 화면의 EmptyView와 기타 화면의 EmptyView 간 폰트 크기 차이가 있더라구요 ㅠ.ㅠ 
이를 해결하기 위해 EmptyView.configure에 font 파라미터를 추가하여 화면별로 폰트를 주입할 수 있도록 수정했습니다.

---

## 📷 Screenshots  

| 기능/화면 | iPhone SE |
|:---------:|:---------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/07f92bb3-957d-4a7f-8b5a-d9638dcf6e77" width="250"> | 
| B 기능 | <img src="https://github.com/user-attachments/assets/2b179c2b-8825-4086-8812-bdda5dc857a5" width="250"> | 

---

## 💬 To Reviewers  
<img width="450" alt="image" src="https://github.com/user-attachments/assets/d57c110f-e17a-4f78-9bcc-7460593bb4ee" />