### PR TITLE
[feature] 커스텀 탭바 구현 

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
@@ -144,11 +144,14 @@ public final class TabBarViewController: UIViewController {
     }
 
     private func setTabBarHidden(_ hidden: Bool, animated: Bool) {
-        guard customTabBarView.isHidden != hidden else { return }
-
         let currentNav = childNavigationControllers[currentIndex]
         let newInset: CGFloat = hidden ? 0 : customTabBarHeight
         let tabBarHeight = customTabBarHeight + view.safeAreaInsets.bottom
+
+        if customTabBarView.isHidden == hidden {
+            currentNav.additionalSafeAreaInsets.bottom = newInset
+            return
+        }
 
         if animated {
             if !hidden {

--- a/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
@@ -144,14 +144,11 @@ public final class TabBarViewController: UIViewController {
     }
 
     private func setTabBarHidden(_ hidden: Bool, animated: Bool) {
+        guard customTabBarView.isHidden != hidden else { return }
+
         let currentNav = childNavigationControllers[currentIndex]
         let newInset: CGFloat = hidden ? 0 : customTabBarHeight
         let tabBarHeight = customTabBarHeight + view.safeAreaInsets.bottom
-
-        if customTabBarView.isHidden == hidden {
-            currentNav.additionalSafeAreaInsets.bottom = newInset
-            return
-        }
 
         if animated {
             if !hidden {

--- a/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
@@ -10,13 +10,10 @@ import SnapKit
 
 public final class TabBarViewController: UIViewController {
 
-    // MARK: - Dependencies
+    // MARK: - Properties
 
     private let factory: ViewControllerFactory
     private let customTabBarHeight: CGFloat = 50
-
-    // MARK: - Child ViewControllers
-
     private var childNavigationControllers: [UINavigationController] = []
     private var currentIndex: Int = 0
 
@@ -30,26 +27,10 @@ public final class TabBarViewController: UIViewController {
     private let containerView = UIView()
 
     private let customTabBarView = CustomTabBarView(items: [
-        .init(
-            title: "홈",
-            selectedImageName: "ic_home_black_24_ios",
-            unselectedImageName: "ic_home_gray_24_ios"
-        ),
-        .init(
-            title: "단어장",
-            selectedImageName: "ic_book_black_24_ios",
-            unselectedImageName: "ic_book_gray_24_ios"
-        ),
-        .init(
-            title: "피드",
-            selectedImageName: "ic_community_black_24_ios",
-            unselectedImageName: "ic_community_gray_24_ios"
-        ),
-        .init(
-            title: "마이",
-            selectedImageName: "ic_my_black_24_ios",
-            unselectedImageName: "ic_my_gray_24_ios"
-        )
+        .init(title: "홈", selectedImageName: "ic_home_black_24_ios", unselectedImageName: "ic_home_gray_24_ios"),
+        .init(title: "단어장", selectedImageName: "ic_book_black_24_ios", unselectedImageName: "ic_book_gray_24_ios"),
+        .init(title: "피드", selectedImageName: "ic_community_black_24_ios", unselectedImageName: "ic_community_gray_24_ios"),
+        .init(title: "마이", selectedImageName: "ic_my_black_24_ios", unselectedImageName: "ic_my_gray_24_ios")
     ])
 
     // MARK: - Init
@@ -68,7 +49,6 @@ public final class TabBarViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        definesPresentationContext = true
         setupChildViewControllers()
         setupUI()
         setupLayout()
@@ -84,12 +64,12 @@ public final class TabBarViewController: UIViewController {
     // MARK: - Setup
 
     private func setupChildViewControllers() {
-        let homeNav = makeNavigationController(root: factory.makeHomeViewController())
-        let vocabNav = makeNavigationController(root: factory.makeWordBookViewController())
-        let feedNav = makeNavigationController(root: factory.makeFeedViewController())
-        let myNav = makeNavigationController(root: factory.makeMypageViewController())
-
-        childNavigationControllers = [homeNav, vocabNav, feedNav, myNav]
+        childNavigationControllers = [
+            makeNavigationController(root: factory.makeHomeViewController()),
+            makeNavigationController(root: factory.makeWordBookViewController()),
+            makeNavigationController(root: factory.makeFeedViewController()),
+            makeNavigationController(root: factory.makeMypageViewController())
+        ]
     }
 
     private func makeNavigationController(root: UIViewController) -> UINavigationController {
@@ -116,16 +96,11 @@ public final class TabBarViewController: UIViewController {
     private func setupTabBarAction() {
         customTabBarView.onSelect = { [weak self] index in
             guard let self else { return }
-            let previousIndex = self.currentIndex
 
-            if previousIndex == index {
-                if index == 2,
-                   let feedVC = self.childNavigationControllers[index].viewControllers.first as? FeedViewController {
-                    feedVC.handleFeedTabSelected(isReSelected: true)
-                }
+            if self.currentIndex == index {
+                self.handleTabReselection(at: index)
                 return
             }
-
             self.selectTab(at: index)
         }
     }
@@ -144,17 +119,24 @@ public final class TabBarViewController: UIViewController {
 
         addChild(newVC)
         containerView.addSubview(newVC.view)
-        newVC.view.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
+        newVC.view.snp.makeConstraints { $0.edges.equalToSuperview() }
         newVC.didMove(toParent: self)
-
         newVC.additionalSafeAreaInsets.bottom = customTabBarHeight
 
         currentIndex = index
         customTabBarView.setSelectedIndex(index)
         updateTabBarVisibility(for: newVC)
     }
+
+    private func handleTabReselection(at index: Int) {
+        guard index == 2,
+              let feedVC = childNavigationControllers[index].viewControllers.first as? FeedViewController else {
+            return
+        }
+        feedVC.handleFeedTabSelected(isReSelected: true)
+    }
+
+    // MARK: - TabBar Visibility
 
     private func updateTabBarVisibility(for navigationController: UINavigationController) {
         let shouldHide = navigationController.topViewController?.hidesBottomBarWhenPushed ?? false
@@ -213,11 +195,11 @@ public extension UIViewController {
 
     var customTabBarController: TabBarViewController? {
         var current: UIViewController? = self
-        while let viewController = current {
-            if let tabBar = viewController as? TabBarViewController {
+        while let vc = current {
+            if let tabBar = vc as? TabBarViewController {
                 return tabBar
             }
-            current = viewController.parent
+            current = vc.parent
         }
         return nil
     }

--- a/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
@@ -166,13 +166,17 @@ public final class TabBarViewController: UIViewController {
 
         let currentNav = childNavigationControllers[currentIndex]
         let newInset: CGFloat = hidden ? 0 : customTabBarHeight
+        let tabBarHeight = customTabBarHeight + view.safeAreaInsets.bottom
 
         if animated {
             if !hidden {
                 customTabBarView.isHidden = false
+                customTabBarView.transform = CGAffineTransform(translationX: 0, y: tabBarHeight)
             }
-            UIView.animate(withDuration: 0.25) {
-                self.customTabBarView.alpha = hidden ? 0 : 1
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
+                self.customTabBarView.transform = hidden
+                    ? CGAffineTransform(translationX: 0, y: tabBarHeight)
+                    : .identity
                 currentNav.additionalSafeAreaInsets.bottom = newInset
             } completion: { _ in
                 if hidden {
@@ -181,7 +185,9 @@ public final class TabBarViewController: UIViewController {
             }
         } else {
             customTabBarView.isHidden = hidden
-            customTabBarView.alpha = hidden ? 0 : 1
+            customTabBarView.transform = hidden
+                ? CGAffineTransform(translationX: 0, y: tabBarHeight)
+                : .identity
             currentNav.additionalSafeAreaInsets.bottom = newInset
         }
     }

--- a/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
@@ -27,10 +27,10 @@ public final class TabBarViewController: UIViewController {
     private let containerView = UIView()
 
     private let customTabBarView = CustomTabBarView(items: [
-        .init(title: "홈", selectedImageName: "ic_home_black_24_ios", unselectedImageName: "ic_home_gray_24_ios"),
-        .init(title: "단어장", selectedImageName: "ic_book_black_24_ios", unselectedImageName: "ic_book_gray_24_ios"),
-        .init(title: "피드", selectedImageName: "ic_community_black_24_ios", unselectedImageName: "ic_community_gray_24_ios"),
-        .init(title: "마이", selectedImageName: "ic_my_black_24_ios", unselectedImageName: "ic_my_gray_24_ios")
+        .init(title: "홈", selectedImage: .icHomeBlack24Ios, unselectedImage: .icHomeGray24Ios),
+        .init(title: "단어장", selectedImage: .icBookBlack24Ios, unselectedImage: .icBookGray24Ios),
+        .init(title: "피드", selectedImage: .icCommunityBlack24Ios, unselectedImage: .icCommunityGray24Ios),
+        .init(title: "마이", selectedImage: .icMyBlack24Ios, unselectedImage: .icMyGray24Ios)
     ])
 
     // MARK: - Init

--- a/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
@@ -113,14 +113,18 @@ public final class TabBarViewController: UIViewController {
         let previousVC = childNavigationControllers[currentIndex]
         let newVC = childNavigationControllers[index]
 
-        previousVC.willMove(toParent: nil)
-        previousVC.view.removeFromSuperview()
-        previousVC.removeFromParent()
+        if previousVC.parent === self, previousVC !== newVC {
+            previousVC.willMove(toParent: nil)
+            previousVC.view.removeFromSuperview()
+            previousVC.removeFromParent()
+        }
 
-        addChild(newVC)
-        containerView.addSubview(newVC.view)
-        newVC.view.snp.makeConstraints { $0.edges.equalToSuperview() }
-        newVC.didMove(toParent: self)
+        if newVC.parent !== self {
+            addChild(newVC)
+            containerView.addSubview(newVC.view)
+            newVC.view.snp.makeConstraints { $0.edges.equalToSuperview() }
+            newVC.didMove(toParent: self)
+        }
         newVC.additionalSafeAreaInsets.bottom = customTabBarHeight
 
         currentIndex = index
@@ -139,7 +143,7 @@ public final class TabBarViewController: UIViewController {
     // MARK: - TabBar Visibility
 
     private func updateTabBarVisibility(for navigationController: UINavigationController) {
-        let shouldHide = navigationController.topViewController?.hidesBottomBarWhenPushed ?? false
+        let shouldHide = navigationController.viewControllers.count > 1
         setTabBarHidden(shouldHide, animated: false)
     }
 
@@ -184,8 +188,12 @@ extension TabBarViewController: UINavigationControllerDelegate {
         willShow viewController: UIViewController,
         animated: Bool
     ) {
-        let shouldHide = viewController.hidesBottomBarWhenPushed
+        let shouldHide = !isRootViewController(viewController, in: navigationController)
         setTabBarHidden(shouldHide, animated: animated)
+    }
+
+    private func isRootViewController(_ viewController: UIViewController, in navigationController: UINavigationController) -> Bool {
+        navigationController.viewControllers.first === viewController
     }
 }
 

--- a/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
@@ -6,125 +6,213 @@
 //
 
 import UIKit
+import SnapKit
 
-public final class TabBarViewController: UITabBarController {
-    
+public final class TabBarViewController: UIViewController {
+
     // MARK: - Dependencies
-    
+
     private let factory: ViewControllerFactory
-    
-    // MARK: - Init
-    
-    public init(diContainer: ViewControllerFactory) {
-        self.factory = diContainer
-        super.init(nibName: nil, bundle: nil)
+    private let customTabBarHeight: CGFloat = 50
+
+    // MARK: - Child ViewControllers
+
+    private var childNavigationControllers: [UINavigationController] = []
+    private var currentIndex: Int = 0
+
+    public var selectedIndex: Int {
+        get { currentIndex }
+        set { selectTab(at: newValue) }
     }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    // MARK: - LifeCycle
-    
-    public override func viewDidLoad() {
-        super.viewDidLoad()
-        delegate = self
-        setupTabBarAppearance()
-        setupViewControllers()
-    }
-    
-    // MARK: - Setup
-    
-    private func setupViewControllers() {
-        let homeVC = makeTabItem(
-            viewController: factory.makeHomeViewController(),
+
+    // MARK: - UI
+
+    private let containerView = UIView()
+
+    private let customTabBarView = CustomTabBarView(items: [
+        .init(
             title: "홈",
             selectedImageName: "ic_home_black_24_ios",
             unselectedImageName: "ic_home_gray_24_ios"
-        )
-        
-        let vocabVC = makeTabItem(
-            viewController: factory.makeWordBookViewController(),
+        ),
+        .init(
             title: "단어장",
             selectedImageName: "ic_book_black_24_ios",
             unselectedImageName: "ic_book_gray_24_ios"
-        )
-        
-        let feedVC = makeTabItem(
-            viewController: factory.makeFeedViewController(),
+        ),
+        .init(
             title: "피드",
             selectedImageName: "ic_community_black_24_ios",
             unselectedImageName: "ic_community_gray_24_ios"
-        )
-        
-        let myVC = makeTabItem(
-            viewController: factory.makeMypageViewController(),
+        ),
+        .init(
             title: "마이",
             selectedImageName: "ic_my_black_24_ios",
             unselectedImageName: "ic_my_gray_24_ios"
         )
-        
-        viewControllers = [homeVC, vocabVC, feedVC, myVC]
+    ])
+
+    // MARK: - Init
+
+    public init(diContainer: ViewControllerFactory) {
+        self.factory = diContainer
+        super.init(nibName: nil, bundle: nil)
     }
-    
-    private func setupTabBarAppearance() {
-        let appearance = UITabBarAppearance()
-        appearance.backgroundColor = .white
-        appearance.shadowColor = .gray200
-        
-        let itemAppearance = UITabBarItemAppearance()
-        itemAppearance.normal.titleTextAttributes = [
-            .font: UIFont.pretendard(.cap_r_12),
-        ]
-        itemAppearance.selected.titleTextAttributes = [
-            .font: UIFont.pretendard(.cap_r_12),
-        ]
-        
-        appearance.stackedLayoutAppearance = itemAppearance
-        
-        tabBar.standardAppearance = appearance
-        tabBar.scrollEdgeAppearance = appearance
-        
-        tabBar.tintColor = .black
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-    
-    private func makeTabItem(
-        viewController: UIViewController,
-        title: String,
-        selectedImageName: String,
-        unselectedImageName: String
-    ) -> UIViewController {
-        let nav = UINavigationController(rootViewController: viewController)
-        nav.tabBarItem = UITabBarItem(
-            title: title,
-            image: UIImage(named: unselectedImageName, in: .module, compatibleWith: nil)?
-                .withRenderingMode(.alwaysOriginal),
-            selectedImage: UIImage(named: selectedImageName, in: .module, compatibleWith: nil)?
-                .withRenderingMode(.alwaysOriginal)
-        )
+
+    // MARK: - LifeCycle
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        definesPresentationContext = true
+        setupChildViewControllers()
+        setupUI()
+        setupLayout()
+        setupTabBarAction()
+        selectTab(at: 0)
+    }
+
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        view.bringSubviewToFront(customTabBarView)
+    }
+
+    // MARK: - Setup
+
+    private func setupChildViewControllers() {
+        let homeNav = makeNavigationController(root: factory.makeHomeViewController())
+        let vocabNav = makeNavigationController(root: factory.makeWordBookViewController())
+        let feedNav = makeNavigationController(root: factory.makeFeedViewController())
+        let myNav = makeNavigationController(root: factory.makeMypageViewController())
+
+        childNavigationControllers = [homeNav, vocabNav, feedNav, myNav]
+    }
+
+    private func makeNavigationController(root: UIViewController) -> UINavigationController {
+        let nav = UINavigationController(rootViewController: root)
+        nav.delegate = self
         return nav
+    }
+
+    private func setupUI() {
+        view.addSubviews(containerView, customTabBarView)
+    }
+
+    private func setupLayout() {
+        containerView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        customTabBarView.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-customTabBarHeight)
+        }
+    }
+
+    private func setupTabBarAction() {
+        customTabBarView.onSelect = { [weak self] index in
+            guard let self else { return }
+            let previousIndex = self.currentIndex
+
+            if previousIndex == index {
+                if index == 2,
+                   let feedVC = self.childNavigationControllers[index].viewControllers.first as? FeedViewController {
+                    feedVC.handleFeedTabSelected(isReSelected: true)
+                }
+                return
+            }
+
+            self.selectTab(at: index)
+        }
+    }
+
+    // MARK: - Tab Selection
+
+    private func selectTab(at index: Int) {
+        guard index >= 0, index < childNavigationControllers.count else { return }
+
+        let previousVC = childNavigationControllers[currentIndex]
+        let newVC = childNavigationControllers[index]
+
+        previousVC.willMove(toParent: nil)
+        previousVC.view.removeFromSuperview()
+        previousVC.removeFromParent()
+
+        addChild(newVC)
+        containerView.addSubview(newVC.view)
+        newVC.view.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        newVC.didMove(toParent: self)
+
+        newVC.additionalSafeAreaInsets.bottom = customTabBarHeight
+
+        currentIndex = index
+        customTabBarView.setSelectedIndex(index)
+        updateTabBarVisibility(for: newVC)
+    }
+
+    private func updateTabBarVisibility(for navigationController: UINavigationController) {
+        let shouldHide = navigationController.topViewController?.hidesBottomBarWhenPushed ?? false
+        setTabBarHidden(shouldHide, animated: false)
+    }
+
+    private func setTabBarHidden(_ hidden: Bool, animated: Bool) {
+        guard customTabBarView.isHidden != hidden else { return }
+
+        let currentNav = childNavigationControllers[currentIndex]
+        let newInset: CGFloat = hidden ? 0 : customTabBarHeight
+
+        if animated {
+            if !hidden {
+                customTabBarView.isHidden = false
+            }
+            UIView.animate(withDuration: 0.25) {
+                self.customTabBarView.alpha = hidden ? 0 : 1
+                currentNav.additionalSafeAreaInsets.bottom = newInset
+            } completion: { _ in
+                if hidden {
+                    self.customTabBarView.isHidden = true
+                }
+            }
+        } else {
+            customTabBarView.isHidden = hidden
+            customTabBarView.alpha = hidden ? 0 : 1
+            currentNav.additionalSafeAreaInsets.bottom = newInset
+        }
     }
 }
 
-// MARK: - Extension
+// MARK: - UINavigationControllerDelegate
 
-extension TabBarViewController: UITabBarControllerDelegate {
-    
-    private static var lastSelectedIndex: Int = 0
-    
-    public func tabBarController(
-        _ tabBarController: UITabBarController,
-        didSelect viewController: UIViewController
+extension TabBarViewController: UINavigationControllerDelegate {
+
+    public func navigationController(
+        _ navigationController: UINavigationController,
+        willShow viewController: UIViewController,
+        animated: Bool
     ) {
-        if tabBarController.selectedIndex == 2,
-           let nav = viewController as? UINavigationController,
-           let feedVC = nav.viewControllers.first as? FeedViewController {
-            
-            let isReSelected = (TabBarViewController.lastSelectedIndex == 2)
-            
-            feedVC.handleFeedTabSelected(isReSelected: isReSelected)
+        let shouldHide = viewController.hidesBottomBarWhenPushed
+        setTabBarHidden(shouldHide, animated: animated)
+    }
+}
+
+// MARK: - UIViewController Extension
+
+public extension UIViewController {
+
+    var customTabBarController: TabBarViewController? {
+        var current: UIViewController? = self
+        while let viewController = current {
+            if let tabBar = viewController as? TabBarViewController {
+                return tabBar
+            }
+            current = viewController.parent
         }
-        
-        TabBarViewController.lastSelectedIndex = tabBarController.selectedIndex
+        return nil
     }
 }

--- a/HilingualPresentation/Sources/Presentation/Common/Components/CustomTabBarView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/CustomTabBarView.swift
@@ -10,8 +10,8 @@ import SnapKit
 
 struct CustomTabBarItem {
     let title: String
-    let selectedImageName: String
-    let unselectedImageName: String
+    let selectedImage: ImageResource
+    let unselectedImage: ImageResource
 }
 
 final class CustomTabBarView: UIView {
@@ -162,9 +162,8 @@ private final class CustomTabBarItemView: UIControl {
     }
 
     private func updateAppearance() {
-        let imageName = isItemSelected ? item.selectedImageName : item.unselectedImageName
-        iconImageView.image = UIImage(named: imageName, in: .module, compatibleWith: nil)?
-            .withRenderingMode(.alwaysOriginal)
+        let imageResource = isItemSelected ? item.selectedImage : item.unselectedImage
+        iconImageView.image = UIImage(resource: imageResource).withRenderingMode(.alwaysOriginal)
         titleLabel.textColor = isItemSelected ? .black : .gray400
     }
 

--- a/HilingualPresentation/Sources/Presentation/Common/Components/CustomTabBarView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/CustomTabBarView.swift
@@ -1,0 +1,177 @@
+//
+//  CustomTabBarView.swift
+//  HilingualPresentation
+//
+//  Created by 성현주 on 3/1/26.
+//
+
+import UIKit
+import SnapKit
+
+struct CustomTabBarItem {
+    let title: String
+    let selectedImageName: String
+    let unselectedImageName: String
+}
+
+final class CustomTabBarView: UIView {
+
+    // MARK: - Callback
+
+    var onSelect: ((Int) -> Void)?
+
+    // MARK: - UI
+
+    private let topDivider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray200
+        return view
+    }()
+
+    private let stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.distribution = .fillEqually
+        return stack
+    }()
+
+    private let itemViews: [CustomTabBarItemView]
+
+    // MARK: - Init
+
+    init(items: [CustomTabBarItem]) {
+        self.itemViews = items.enumerated().map { index, item in
+            CustomTabBarItemView(index: index, item: item)
+        }
+        super.init(frame: .zero)
+        setupUI()
+        setupLayout()
+        bindActions()
+        setSelectedIndex(0)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public
+
+    func setSelectedIndex(_ index: Int) {
+        itemViews.forEach { $0.isItemSelected = ($0.itemIndex == index) }
+    }
+
+    // MARK: - Private
+
+    private func setupUI() {
+        backgroundColor = .white
+        addSubviews(topDivider, stackView)
+        itemViews.forEach { stackView.addArrangedSubview($0) }
+    }
+
+    private func setupLayout() {
+        topDivider.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+
+        stackView.snp.makeConstraints {
+            $0.top.equalTo(topDivider.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide)
+        }
+    }
+
+    private func bindActions() {
+        itemViews.forEach { itemView in
+            itemView.onTap = { [weak self] index in
+                self?.onSelect?(index)
+            }
+        }
+    }
+}
+
+private final class CustomTabBarItemView: UIControl {
+
+    // MARK: - Callback
+
+    var onTap: ((Int) -> Void)?
+
+    // MARK: - Properties
+
+    let itemIndex: Int
+    private let item: CustomTabBarItem
+
+    var isItemSelected: Bool = false {
+        didSet { updateUI() }
+    }
+
+    // MARK: - UI
+
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .pretendard(.cap_r_12)
+        label.textAlignment = .center
+        return label
+    }()
+
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 2
+        return stack
+    }()
+
+    // MARK: - Init
+
+    init(index: Int, item: CustomTabBarItem) {
+        self.itemIndex = index
+        self.item = item
+        super.init(frame: .zero)
+        setupUI()
+        setupLayout()
+        addTarget(self, action: #selector(didTap), for: .touchUpInside)
+        updateUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Private
+
+    private func setupUI() {
+        titleLabel.text = item.title
+        addSubview(contentStack)
+        contentStack.addArrangedSubviews(iconImageView, titleLabel)
+        contentStack.isUserInteractionEnabled = false
+    }
+
+    private func setupLayout() {
+        contentStack.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+
+        iconImageView.snp.makeConstraints {
+            $0.size.equalTo(24)
+        }
+    }
+
+    private func updateUI() {
+        let imageName = isItemSelected ? item.selectedImageName : item.unselectedImageName
+        iconImageView.image = UIImage(named: imageName, in: .module, compatibleWith: nil)?
+            .withRenderingMode(.alwaysOriginal)
+        titleLabel.textColor = isItemSelected ? .black : .gray400
+    }
+
+    @objc
+    private func didTap() {
+        onTap?(itemIndex)
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Common/Components/CustomTabBarView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/CustomTabBarView.swift
@@ -47,7 +47,6 @@ final class CustomTabBarView: UIView {
         setupUI()
         setupLayout()
         bindActions()
-        setSelectedIndex(0)
     }
 
     required init?(coder: NSCoder) {
@@ -90,19 +89,18 @@ final class CustomTabBarView: UIView {
     }
 }
 
+// MARK: - CustomTabBarItemView
+
 private final class CustomTabBarItemView: UIControl {
-
-    // MARK: - Callback
-
-    var onTap: ((Int) -> Void)?
 
     // MARK: - Properties
 
     let itemIndex: Int
     private let item: CustomTabBarItem
+    var onTap: ((Int) -> Void)?
 
     var isItemSelected: Bool = false {
-        didSet { updateUI() }
+        didSet { updateAppearance() }
     }
 
     // MARK: - UI
@@ -125,6 +123,7 @@ private final class CustomTabBarItemView: UIControl {
         stack.axis = .vertical
         stack.alignment = .center
         stack.spacing = 2
+        stack.isUserInteractionEnabled = false
         return stack
     }()
 
@@ -137,7 +136,6 @@ private final class CustomTabBarItemView: UIControl {
         setupUI()
         setupLayout()
         addTarget(self, action: #selector(didTap), for: .touchUpInside)
-        updateUI()
     }
 
     required init?(coder: NSCoder) {
@@ -150,7 +148,7 @@ private final class CustomTabBarItemView: UIControl {
         titleLabel.text = item.title
         addSubview(contentStack)
         contentStack.addArrangedSubviews(iconImageView, titleLabel)
-        contentStack.isUserInteractionEnabled = false
+        updateAppearance()
     }
 
     private func setupLayout() {
@@ -163,7 +161,7 @@ private final class CustomTabBarItemView: UIControl {
         }
     }
 
-    private func updateUI() {
+    private func updateAppearance() {
         let imageName = isItemSelected ? item.selectedImageName : item.unselectedImageName
         iconImageView.image = UIImage(named: imageName, in: .module, compatibleWith: nil)?
             .withRenderingMode(.alwaysOriginal)

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/BaseUIViewController+Dialog.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/BaseUIViewController+Dialog.swift
@@ -52,6 +52,9 @@ extension UIApplication {
         if let tab = base as? UITabBarController {
             return tab.selectedViewController.flatMap { topViewController(base: $0) }
         }
+        if let customTab = base as? TabBarViewController {
+            return topViewController(base: customTab.children.first)
+        }
         if let presented = base?.presentedViewController {
             return topViewController(base: presented)
         }

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift
@@ -236,7 +236,7 @@ public final class DiaryDetailViewController: BaseUIViewController<DiaryDetailVi
                                 entryId: self?.entryId ?? ""
                             )
                         )
-                        self?.tabBarController?.selectedIndex = 2
+                        self?.customTabBarController?.selectedIndex = 2
                         self?.navigationController?.popToRootViewController(animated: false)
                     }
 

--- a/HilingualPresentation/Sources/Presentation/Feed/FeedViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Feed/FeedViewController.swift
@@ -151,11 +151,11 @@ public final class FeedViewController: BaseUIViewController<FeedViewModel> {
     }
 
     func showHideDialog(listVC: FeedListViewController, row: Int) {
-        guard let containerView = self.tabBarController?.view else { return }
-        
-        containerView.addSubview(dialog)
-        dialog.snp.remakeConstraints { $0.edges.equalTo(containerView) }
-        
+        guard let window = view.window else { return }
+
+        window.addSubview(dialog)
+        dialog.snp.remakeConstraints { $0.edges.equalToSuperview() }
+
         dialog.configure(
             style: .normal,
             title: "영어 일기를 비공개 하시겠어요?",
@@ -181,15 +181,14 @@ public final class FeedViewController: BaseUIViewController<FeedViewModel> {
         )
         dialog.isHidden = false
         dialog.showAnimation()
-        containerView.bringSubviewToFront(dialog)
     }
 
     private func showReportDialog() {
-        guard let containerView = self.tabBarController?.view else { return }
-        
-        containerView.addSubview(dialog)
-        dialog.snp.remakeConstraints { $0.edges.equalTo(containerView) }
-        
+        guard let window = view.window else { return }
+
+        window.addSubview(dialog)
+        dialog.snp.remakeConstraints { $0.edges.equalToSuperview() }
+
         dialog.configure(
             style: .normal,
             title: "게시글을 신고하시겠어요?",
@@ -206,7 +205,6 @@ public final class FeedViewController: BaseUIViewController<FeedViewModel> {
         )
         dialog.isHidden = false
         dialog.showAnimation()
-        containerView.bringSubviewToFront(dialog)
     }
 
     private func openReportPage() {

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -287,10 +287,10 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     }
     
     private func showDraftDialog(selectedDate: Date, topicData: (String, String)?) {
-        guard let containerView = self.tabBarController?.view else { return }
+        guard let window = view.window else { return }
 
-        containerView.addSubview(dialog)
-        dialog.snp.remakeConstraints { $0.edges.equalTo(containerView) }
+        window.addSubview(dialog)
+        dialog.snp.remakeConstraints { $0.edges.equalToSuperview() }
 
         dialog.configure(
             style: .normal,
@@ -381,36 +381,34 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     }
     
     private func showOverlay() {
-        guard let containerView = tabBarController?.view ?? view else { return }
-        
         let overlay = UIControl()
         overlay.backgroundColor = .clear
         overlay.addTarget(self, action: #selector(dismissMenu), for: .touchUpInside)
-        containerView.addSubview(overlay)
+        view.addSubview(overlay)
         overlay.snp.makeConstraints { $0.edges.equalToSuperview() }
         overlayView = overlay
-        
+
         if homeView.selectedInfo.menu.superview != nil {
             homeView.selectedInfo.menu.removeFromSuperview()
         }
-        containerView.addSubview(homeView.selectedInfo.menu)
-        
+        view.addSubview(homeView.selectedInfo.menu)
+
         homeView.selectedInfo.menu.snp.remakeConstraints {
             $0.top.equalTo(homeView.selectedInfo.moreImageView.snp.bottom).offset(4)
             $0.trailing.equalTo(homeView.selectedInfo.moreImageView.snp.trailing)
             $0.height.equalTo(96)
             $0.width.equalTo(182)
         }
-        
+
         homeView.selectedInfo.menu.isHidden = false
-        containerView.bringSubviewToFront(homeView.selectedInfo.menu)
+        view.bringSubviewToFront(homeView.selectedInfo.menu)
     }
     
     private func showDialog(for action: MenuAction, diaryId: Int) {
-        guard let containerView = self.tabBarController?.view else { return }
-        
-        containerView.addSubview(dialog)
-        dialog.snp.remakeConstraints { $0.edges.equalTo(containerView) }
+        guard let window = view.window else { return }
+
+        window.addSubview(dialog)
+        dialog.snp.remakeConstraints { $0.edges.equalToSuperview() }
         
         switch action {
         case .publish:
@@ -446,7 +444,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
                             
                             toast.action = { [weak self] in
                                 guard let self else { return }
-                                tabBarController?.selectedIndex = 2
+                                customTabBarController?.selectedIndex = 2
                             }
                         })
                         .store(in: &self.viewModel!.cancellables)

--- a/HilingualPresentation/Sources/Presentation/WordBook/WordBookViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/WordBook/WordBookViewController.swift
@@ -229,7 +229,7 @@ public final class WordBookViewController: BaseUIViewController<WordBookViewMode
     @objc
     private func didTapEmptyAdd() {
         print("일기 쓰러 이동")
-        tabBarController?.selectedIndex = 0
+        customTabBarController?.selectedIndex = 0
     }
 
     @objc


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #384 

---

## 📎 Work Description 
- 커스텀 탭바를 구현했습니다. 

## 변경 요약
- `TabBarViewController`를 `UITabBarController` 기반에서 커스텀 컨테이너 기반으로 전환했습니다.
- 신규 `CustomTabBarView`를 추가해 탭 UI/선택 상태를 직접 제어하도록 변경했습니다.
- 탭 전환 시 child `UINavigationController`를 붙였다 떼는 구조로 바꾸고, `hidesBottomBarWhenPushed`에 따라 커스텀 탭바 숨김/표시 애니메이션을 연동했습니다.
- 기존 `tabBarController?.selectedIndex` 의존 코드를 `customTabBarController?.selectedIndex`로 마이그레이션했습니다.
- 다이얼로그 표시 레이어를 `tabBarController.view`에서 `window`로 옮겨, 커스텀 탭바/화면 계층과 충돌 없이 항상 최상단에 표시되도록 정리했습니다.

## 상세 로직 설명
1. 탭바 구조 변경
- [TabBarViewController.swift:11](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:11)에서 `UIViewController`가 직접 탭 컨테이너 역할을 수행합니다.
- [TabBarViewController.swift:66](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:66)에서 탭별 root VC를 `UINavigationController`로 생성해 보관합니다.
- [TabBarViewController.swift:110](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:110)에서 탭 변경 시 기존 child nav 제거 후 신규 child nav를 `containerView`에 attach합니다.
- [TabBarViewController.swift:124](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:124)로 하단 safe area inset을 직접 보정해 콘텐츠가 탭바에 가리지 않게 처리합니다.

2. 커스텀 탭 UI 및 선택 이벤트
- [CustomTabBarView.swift:17](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Components/CustomTabBarView.swift:17)에 탭 아이템 뷰(아이콘+텍스트)를 수평 스택으로 구성했습니다.
- [CustomTabBarView.swift:58](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Components/CustomTabBarView.swift:58)에서 선택 인덱스를 받아 각 아이템의 선택 상태를 업데이트합니다.
- [TabBarViewController.swift:96](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:96)에서 `onSelect` 콜백을 받아 탭 전환/재선택을 분기합니다.

3. 탭 재선택(피드 탭) 동작
- [TabBarViewController.swift:131](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:131)에서 현재 탭 재탭 시(특히 피드 index=2) `FeedViewController.handleFeedTabSelected(isReSelected: true)`를 호출합니다.
- [FeedViewController.swift:232](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Feed/FeedViewController.swift:232)에서 재선택이면 현재 세그먼트 기준으로 목록 refresh + 스크롤 top 이동을 수행합니다.

4. `hidesBottomBarWhenPushed` 연동 및 애니메이션
- [TabBarViewController.swift:180](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:180)에서 `UINavigationControllerDelegate`의 `willShow`를 받아, push 대상 VC의 `hidesBottomBarWhenPushed`를 읽습니다.
- [TabBarViewController.swift:146](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:146)에서 탭바 hide/show를 transform 애니메이션으로 처리하고, 같은 타이밍에 `additionalSafeAreaInsets.bottom`도 동기화합니다.

5. 화면 간 탭 이동 인터페이스 통일
- [TabBarViewController.swift:194](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:194)에 `UIViewController.customTabBarController` 접근자를 추가했습니다.
- 이를 사용해 아래 코드들을 `customTabBarController?.selectedIndex`로 치환했습니다.
- [DiaryDetailViewController.swift:239](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift:239)
- [HomeViewController.swift:447](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift:447)
- [WordBookViewController.swift:232](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/WordBook/WordBookViewController.swift:232)

6. 다이얼로그/오버레이 계층 안정화
- `tabBarController?.view` 기준 addSubview는 커스텀 컨테이너 전환 후 레이어 충돌 가능성이 있어 `window` 기준으로 변경했습니다.
- [FeedViewController.swift:153](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Feed/FeedViewController.swift:153), [FeedViewController.swift:186](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Feed/FeedViewController.swift:186), [HomeViewController.swift:289](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift:289), [HomeViewController.swift:407](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift:407)
- 앱 전역 top VC 탐색 로직에도 커스텀 탭 컨테이너를 인지하도록 보강했습니다: [BaseUIViewController+Dialog.swift:55](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Extensions/BaseUIViewController+Dialog.swift:55)

# 상세 설명(사실 그냥 코드보면 이해될거긴함)

### 1. 탭바 컨테이너 구조 전환
기존 `UITabBarController` 상속 대신, `TabBarViewController`가 직접 child `UINavigationController`를 붙였다/떼는 방식으로 동작합니다.  
참고: [TabBarViewController.swift:11](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:11)

```swift
public final class TabBarViewController: UIViewController {
    private var childNavigationControllers: [UINavigationController] = []
    private var currentIndex: Int = 0

    public var selectedIndex: Int {
        get { currentIndex }
        set { selectTab(at: newValue) }
    }
}
```

핵심은 `selectedIndex`를 직접 제어해서 탭 전환 API를 유지한 점입니다.

---

### 2. 탭 전환 로직 (child 교체)
탭 선택 시 이전 child nav 제거, 새 child nav 추가, safe area inset 동기화까지 수행합니다.  
참고: [TabBarViewController.swift:110](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:110)

```swift
private func selectTab(at index: Int) {
    let previousVC = childNavigationControllers[currentIndex]
    let newVC = childNavigationControllers[index]

    previousVC.willMove(toParent: nil)
    previousVC.view.removeFromSuperview()
    previousVC.removeFromParent()

    addChild(newVC)
    containerView.addSubview(newVC.view)
    newVC.view.snp.makeConstraints { $0.edges.equalToSuperview() }
    newVC.didMove(toParent: self)
    newVC.additionalSafeAreaInsets.bottom = customTabBarHeight

    currentIndex = index
    customTabBarView.setSelectedIndex(index)
    updateTabBarVisibility(for: newVC)
}
```

이 구조 덕분에 커스텀 탭바와 내비게이션 스택을 분리해 제어할 수 있습니다.

---

### 3. 커스텀 탭 UI 이벤트 연결
`CustomTabBarView`는 탭 아이템 뷰만 담당하고, 실제 전환은 `onSelect` 콜백으로 위임합니다.  
참고: [CustomTabBarView.swift:17](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Components/CustomTabBarView.swift:17), [TabBarViewController.swift:96](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:96)

```swift
// CustomTabBarView
var onSelect: ((Int) -> Void)?

func setSelectedIndex(_ index: Int) {
    itemViews.forEach { $0.isItemSelected = ($0.itemIndex == index) }
}
```

```swift
// TabBarViewController
customTabBarView.onSelect = { [weak self] index in
    guard let self else { return }
    if self.currentIndex == index {
        self.handleTabReselection(at: index)
        return
    }
    self.selectTab(at: index)
}
```

---

### 4. 재선택 동작 (피드 탭 refresh)
피드 탭(index 2) 재탭 시 `FeedViewController`에 재선택 이벤트를 명시적으로 전달합니다.  
참고: [TabBarViewController.swift:131](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:131), [FeedViewController.swift:232](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Feed/FeedViewController.swift:232)

```swift
private func handleTabReselection(at index: Int) {
    guard index == 2,
          let feedVC = childNavigationControllers[index].viewControllers.first as? FeedViewController else { return }
    feedVC.handleFeedTabSelected(isReSelected: true)
}
```

```swift
public func handleFeedTabSelected(isReSelected: Bool) {
    if isReSelected {
        if feedView.segmentedControl?.setSelectedIndexWithAPI == 0 {
            resetRecommendFeed()
        } else {
            resetFollowingFeed()
        }
    } else {
        feedView.setSelectedIndexUIOnly(0)
        recommendFeedVC.resetScrollPosition()
    }
}
```

---

### 5. `hidesBottomBarWhenPushed` 연동
각 탭의 `UINavigationControllerDelegate`에서 push/pop 시점마다 탭바 표시 여부를 자동 반영합니다.  
참고: [TabBarViewController.swift:180](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:180)

```swift
public func navigationController(
    _ navigationController: UINavigationController,
    willShow viewController: UIViewController,
    animated: Bool
) {
    let shouldHide = viewController.hidesBottomBarWhenPushed
    setTabBarHidden(shouldHide, animated: animated)
}
```

`setTabBarHidden` 내부에서 탭바 transform 애니메이션 + `additionalSafeAreaInsets.bottom`를 같이 조정해서 레이아웃 점프를 줄였습니다.

---

### 6. 전역 탭 접근 API 통일
기존 `tabBarController?.selectedIndex` 호출 지점을 커스텀 컨테이너에 맞춰 통일했습니다.  
참고: [TabBarViewController.swift:194](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift:194)

```swift
public extension UIViewController {
    var customTabBarController: TabBarViewController? {
        var current: UIViewController? = self
        while let vc = current {
            if let tabBar = vc as? TabBarViewController { return tabBar }
            current = vc.parent
        }
        return nil
    }
}
```

적용 예시:
- [DiaryDetailViewController.swift:239](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift:239)
- [HomeViewController.swift:447](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift:447)
- [WordBookViewController.swift:232](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/WordBook/WordBookViewController.swift:232)

---

### 7. 다이얼로그 레이어 기준 변경
커스텀 탭바 구조에서 `tabBarController?.view` 기준 오버레이는 계층 충돌 위험이 있어 `window` 기준으로 변경했습니다.  
참고: [FeedViewController.swift:153](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Feed/FeedViewController.swift:153), [HomeViewController.swift:289](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift:289)

```swift
guard let window = view.window else { return }
window.addSubview(dialog)
dialog.snp.remakeConstraints { $0.edges.equalToSuperview() }
```

또한 전역 top VC 탐색도 커스텀 탭을 인식하도록 보강했습니다.  
참고: [BaseUIViewController+Dialog.swift:55](/Users/seonghyeonju/Desktop/Hilingual-iOS/HilingualPresentation/Sources/Presentation/Common/Extensions/BaseUIViewController+Dialog.swift:55)

---

## 구조도

```mermaid
flowchart TD
    A["TabBarViewController (Container)"] --> B["containerView (화면 영역)"]
    A --> C["CustomTabBarView (하단 탭 UI)"]

    B --> D["UINavigationController[Home]"]
    B --> E["UINavigationController[WordBook]"]
    B --> F["UINavigationController[Feed]"]
    B --> G["UINavigationController[My]"]

    C -->|"onSelect(index)"| A
    A -->|"selectTab(at:)"| B
    A -->|"setSelectedIndex"| C

    D -->|"willShow / hidesBottomBarWhenPushed"| A
    E -->|"willShow / hidesBottomBarWhenPushed"| A
    F -->|"willShow / hidesBottomBarWhenPushed"| A
    G -->|"willShow / hidesBottomBarWhenPushed"| A

    A -->|"setTabBarHidden + safeAreaInset"| C
    A -->|"Feed 재탭 시 handleFeedTabSelected(true)"| F
```

---

## 📷 Screenshots  

![Simulator Screen Recording - iPhone 17 Pro - 2026-03-05 at 22 46 06](https://github.com/user-attachments/assets/d6ec1f84-d621-48df-a4c1-b588a0c52bde)


| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| A 기능 | <img src="" width="250"> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
