### PR TITLE
[chore] 특수문자 제한 삭제

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/TextView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/TextView.swift
@@ -189,26 +189,23 @@ extension TextView: UITextViewDelegate {
         layer.borderWidth = 0
     }
     
-    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+    func textView(
+        _ textView: UITextView,
+        shouldChangeTextIn range: NSRange,
+        replacementText text: String
+    ) -> Bool {
+        
         if text.contains(where: { $0.isEmoji }) {
             return false
         }
-        
-        let allowedPunctuation: Set<Character> = [".", ",", "!", "?", "'", "\"", "-", ":", ";", "(", ")", "[", "]", "{", "}", "…"]
-        let isAllowed = text.allSatisfy { char in
-            char.isLetter || char.isNumber || char.isWhitespace || allowedPunctuation.contains(char)
-        }
-        
-        if !isAllowed {
-            return false
-        }
-        
+
         guard let currentText = textView.text else { return true }
-        
+
         if let stringRange = Range(range, in: currentText) {
             let updatedText = currentText.replacingCharacters(in: stringRange, with: text)
             return updatedText.count <= maxCharacterCount
         }
+
         return true
     }
 }


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [x] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #401 

---

## 📎 Work Description 
- 일기 작성하기 내 특수문자 제한을 삭제했습니다. 

---

## 📷 Screenshots  

| 기능/화면 | iPhone 16 Pro |
|:---------:|:---------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/e29de5b5-28c7-41bd-8d77-0e059c6fb15d" width="250"> |

---

## 💬 To Reviewers  
이전에는 +, - 같은 특수문자가 허용되지 않았는데 해당 제한을 제거하니 +, -가 포함된 문장도 복붙이 정상적으로 됩니다!