### PR TITLE
[fix] 토스트메시지 레이아웃 버그리포트 수정

### DIFF
--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift
@@ -228,6 +228,10 @@ public final class DiaryDetailViewController: BaseUIViewController<DiaryDetailVi
 
                 let toast = ToastMessage()
                 self.view.addSubview(toast)
+                
+                toast.snp.makeConstraints {
+                    $0.bottom.equalToSuperview().inset(116)
+                }
 
                 if isPublished {
                     toast.configure(type: .withButton, message: "일기가 게시되었어요!")


### PR DESCRIPTION
## ✅ Check List
- [x] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [x] 2인 이상의 Approve를 받은 후 머지해주세요.
- [x] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #411

---

## 📎 Work Description 
기존 탭바를 커스텀 탭바로 변경하면서 토스트메시지 레이아웃이 뒤에 있는 '게시하기', '비공개하기' 버튼과 겹쳐져보이는 문제가 발생하여 이를 해결했습니다!

---

## 📷 Screenshots  

| 기능/화면 | iPhone SE |
|:---------:|:---------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/fe26be42-0a74-4d33-92d0-72ee06c5b4d7" width="250"> |

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
변경사항 단 3줄. bottom 위치 제약만 추가해주었습니다