### PR TITLE
[feat] 일기 상세화면 주제 드롭다운 추가

### DIFF
--- a/Hilingual.xcodeproj/project.pbxproj
+++ b/Hilingual.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 /* Begin XCBuildConfiguration section */
 		E5C79B222E15281B00E461C3 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3A091AE92F8F923E004D27CF /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon$(BUNDLE_ID_SUFFIX)";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -297,6 +298,7 @@
 		};
 		E5C79B232E15281B00E461C3 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3A091AE72F8F922B004D27CF /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon$(BUNDLE_ID_SUFFIX)";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/Hilingual/App/AppDIContainer.swift
+++ b/Hilingual/App/AppDIContainer.swift
@@ -60,7 +60,8 @@ final class AppDIContainer: ViewControllerFactory {
         let viewModel = FeedbackViewModel(
                 diaryId: diaryId,
                 diaryDetailUseCase: makeDiaryDetailUseCase(),
-                feedbackUseCase: makeFeedbackUseCase()
+                feedbackUseCase: makeFeedbackUseCase(),
+                homeUseCase: makeHomeUseCase()
             )
             return FeedbackViewController(viewModel: viewModel, diContainer:  self)
     }
@@ -389,7 +390,7 @@ extension AppDIContainer {
     }
         
     private func makeFeedbackViewModel(diaryId: Int) -> FeedbackViewModel {
-        return FeedbackViewModel(diaryId: diaryId, diaryDetailUseCase: makeDiaryDetailUseCase(), feedbackUseCase: makeFeedbackUseCase())
+        return FeedbackViewModel(diaryId: diaryId, diaryDetailUseCase: makeDiaryDetailUseCase(), feedbackUseCase: makeFeedbackUseCase(), homeUseCase: makeHomeUseCase())
     }
     
     private func makeFeedbackUseCase() -> FeedbackUseCase {

--- a/HilingualPresentation/Sources/Presentation/Common/Components/Dropdown.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Dropdown.swift
@@ -7,6 +7,32 @@
 
 import UIKit
 
+enum DropdownStyle {
+    case today
+    case selectedDate
+
+    var backgroundColor: UIColor {
+        switch self {
+        case .today: return .gray100
+        case .selectedDate: return .white
+        }
+    }
+
+    var contentBackgroundColor: UIColor {
+        switch self {
+        case .today: return .white
+        case .selectedDate: return .gray100
+        }
+    }
+    
+    var titleText: String {
+        switch self {
+        case .today: return "오늘의 추천 주제 참고하기"
+        case .selectedDate: return "이날의 추천 주제 참고하기"
+        }
+    }
+}
+
 final class Dropdown: UIView {
 
     // MARK: - Properties
@@ -103,6 +129,15 @@ final class Dropdown: UIView {
         setActions()
     }
 
+    init(frame: CGRect = .zero, style: DropdownStyle) {
+        super.init(frame: frame)
+        setStyle()
+        setUI()
+        setLayout()
+        setActions()
+        applyStyle(style)
+    }
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -183,5 +218,21 @@ final class Dropdown: UIView {
     // MARK: - Public Methods
     func addDropdownToggleAction(_ action: @escaping () -> Void) {
         self.onToggleAction = action
+    }
+}
+
+// MARK: - Extension
+
+extension Dropdown {
+
+    func applyStyle(_ style: DropdownStyle) {
+        backgroundColor = style.backgroundColor
+        
+        dropdownBackgroundStack.backgroundColor = style.backgroundColor
+        dropdownHeaderStack.backgroundColor = style.backgroundColor
+        
+        dropdownContentStack.backgroundColor = style.contentBackgroundColor
+        
+        titleLabel.text = style.titleText
     }
 }

--- a/HilingualPresentation/Sources/Presentation/Common/Extensions/String+Date.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Extensions/String+Date.swift
@@ -1,0 +1,47 @@
+//
+//  String+Date.swift
+//  HilingualPresentation
+//
+//  Created by youngseo on 4/15/26.
+//
+
+import Foundation
+
+extension String {
+    
+    func toAPIDate() -> String? {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "M월 d일 EEEE"
+        
+        guard let parsedDate = formatter.date(from: self) else { return nil }
+        
+        let calendar = Calendar.current
+        let month = calendar.component(.month, from: parsedDate)
+        let day = calendar.component(.day, from: parsedDate)
+        let targetWeekday = calendar.component(.weekday, from: parsedDate)
+        
+        let currentYear = calendar.component(.year, from: Date())
+        
+        for year in stride(from: currentYear, through: currentYear - 2, by: -1) {
+            var components = DateComponents()
+            components.year = year
+            components.month = month
+            components.day = day
+            
+            if let candidate = calendar.date(from: components),
+               calendar.component(.weekday, from: candidate) == targetWeekday {
+                
+                return candidate.toFormattedString("yyyy-MM-dd")
+            }
+        }
+        
+        var fallback = DateComponents()
+        fallback.year = currentYear
+        fallback.month = month
+        fallback.day = day
+        
+        guard let fallbackDate = calendar.date(from: fallback) else { return nil }
+        return fallbackDate.toFormattedString("yyyy-MM-dd")
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackView.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackView.swift
@@ -39,7 +39,9 @@ final class FeedbackView: BaseUIView {
         label.text = "교정된 일기"
         return label
     }()
-
+    
+    let dropdown = Dropdown(style: .selectedDate)
+    
     lazy var controlSwitch: CustomToggle = {
         let toggle = CustomToggle(frame: CGRect(x: 0, y: 0, width: 52, height: 28))
         toggle.addTarget(self, action: #selector(toggleButtonTapped), for: .valueChanged)
@@ -122,7 +124,7 @@ final class FeedbackView: BaseUIView {
         addSubview(scrollView)
         scrollView.addSubview(contentView)
         contentView.axis = .vertical
-        contentView.addArrangedSubviews(headerStackView, diaryTextView, feedbackStackView, bottomSpacingView)
+        contentView.addArrangedSubviews(headerStackView, dropdown, diaryTextView, feedbackStackView, bottomSpacingView)
         headerStackView.addArrangedSubviews(dateLabel, AILabel, controlSwitch)
         feedbackStackView.addArrangedSubview(feedbackLabel)
 
@@ -138,6 +140,7 @@ final class FeedbackView: BaseUIView {
         }
 
         contentView.setCustomSpacing(12, after: headerStackView)
+        contentView.setCustomSpacing(12, after: dropdown)
         headerStackView.setCustomSpacing(4, after: AILabel)
 
         controlSwitch.snp.makeConstraints {
@@ -148,6 +151,10 @@ final class FeedbackView: BaseUIView {
         contentView.layoutMargins = UIEdgeInsets(top: 18, left: 16, bottom: 0, right: 16)
         contentView.isLayoutMarginsRelativeArrangement = true
 
+        dropdown.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+        }
+        
         diaryTextView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16)
         }
@@ -194,6 +201,10 @@ final class FeedbackView: BaseUIView {
     }
 
     // MARK: - Configure
+
+    func setTopic(kor: String, en: String) {
+        dropdown.configure(kor: kor, en: en)
+    }
 
     func configureDiary(data: DiaryViewData) {
         currentDiaryData = data

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackViewController.swift
@@ -138,6 +138,17 @@ public final class FeedbackViewController: BaseUIViewController<FeedbackViewMode
     }
 
     private func bindOutput(_ output: FeedbackViewModel.Output) {
+        
+        output.fetchTopicResult
+            .receive(on: RunLoop.main)
+            .sink { [weak self] topic in
+                self?.feedbackView.setTopic(
+                    kor: topic.topicKor,
+                    en: topic.topicEn
+                )
+            }
+            .store(in: &cancellables)
+        
         output.fetchFeedbackResult
             .receive(on: RunLoop.main)
             .sink(

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackViewModel.swift
@@ -69,7 +69,6 @@ public final class FeedbackViewModel: BaseViewModel{
                     })
                     .store(in: &self.cancellables)
                 
-                
                 self.diaryDetailUseCase.fetchDiaryDetail(diaryId: diaryId)
                     .sink(
                         receiveCompletion: { [weak self] completion in

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import Combine
-
 import HilingualDomain
 
 public final class FeedbackViewModel: BaseViewModel{
@@ -24,6 +23,7 @@ public final class FeedbackViewModel: BaseViewModel{
     struct Output {
         let fetchDiaryResult: AnyPublisher<DiaryDetailEntity, Never>
         let fetchFeedbackResult: AnyPublisher<[DiaryFeedbackEntity], Never>
+        let fetchTopicResult: AnyPublisher<TopicEntity, Never>
         let errorMessage: AnyPublisher<String, Never>
     }
     
@@ -31,22 +31,30 @@ public final class FeedbackViewModel: BaseViewModel{
     
     private let diaryDetailUseCase: DiaryDetailUseCase
     private let feedbackUseCase: FeedbackUseCase
+    private let homeUseCase: HomeUseCase
     
     private let diaryDetailSubject = PassthroughSubject<DiaryDetailEntity, Never>()
     private let feedbackSubject = PassthroughSubject<[DiaryFeedbackEntity], Never>()
+    private let topicSubject = PassthroughSubject<TopicEntity, Never>()
     private let errorSubject = PassthroughSubject<String, Never>()
     
-    public init(diaryId: Int, diaryDetailUseCase: DiaryDetailUseCase,
-                feedbackUseCase: FeedbackUseCase) {
+    public init(
+        diaryId: Int,
+        diaryDetailUseCase: DiaryDetailUseCase,
+        feedbackUseCase: FeedbackUseCase,
+        homeUseCase: HomeUseCase
+    ) {
         self.diaryId = diaryId
         self.diaryDetailUseCase = diaryDetailUseCase
         self.feedbackUseCase = feedbackUseCase
+        self.homeUseCase = homeUseCase
     }
     
     func transform(input: Input) -> Output {
         input.viewDidLoad
             .sink { [weak self] in
                 guard let self = self else { return }
+                
                 self.feedbackUseCase.fetchFeedback(diaryId: diaryId)
                     .sink(receiveCompletion: { [weak self] completion in
                         switch completion {
@@ -58,24 +66,48 @@ public final class FeedbackViewModel: BaseViewModel{
                     }, receiveValue: { [weak self] entity in
                         let feedbackData = entity
                         self?.feedbackSubject.send(feedbackData)
-                        print("feedbackData: \(feedbackData)")
                     })
                     .store(in: &self.cancellables)
                 
+                
                 self.diaryDetailUseCase.fetchDiaryDetail(diaryId: diaryId)
-                                .sink(receiveCompletion: { [weak self] completion in
-                                    if case let .failure(error) = completion {
-                                        self?.errorSubject.send("일기 상세 조회 실패: \(error.localizedDescription)")
-                                    }
-                                }, receiveValue: { [weak self] detail in
-                                    self?.diaryDetailSubject.send(detail)
-                                })
-                                .store(in: &self.cancellables)
+                    .sink(
+                        receiveCompletion: { [weak self] completion in
+                            if case let .failure(error) = completion {
+                                self?.errorSubject.send("일기 상세 조회 실패: \(error.localizedDescription)")
+                            }
+                        },
+                        receiveValue: { [weak self] detail in
+                            guard let self else { return }
+                            
+                            self.diaryDetailSubject.send(detail)
+                            
+                            if let apiDate = detail.date.toAPIDate() {
+                                self.homeUseCase.fetchTopic(for: apiDate)
+                                    .sink(
+                                        receiveCompletion: { completion in
+                                            if case let .failure(error) = completion {
+                                                print("일기 상세화면 - 주제 조회 실패:", error)
+                                            }
+                                        },
+                                        receiveValue: { [weak self] topic in
+                                            guard let topic else { return }
+                                            self?.topicSubject.send(topic)
+                                        }
+                                    )
+                                    .store(in: &self.cancellables)
+                            }
+                        }
+                    )
+                    .store(in: &self.cancellables)
             }
             .store(in: &cancellables)
+        
+        
         return Output(
             fetchDiaryResult: diaryDetailSubject.eraseToAnyPublisher(),
             fetchFeedbackResult: feedbackSubject.eraseToAnyPublisher(),
+            fetchTopicResult: topicSubject.eraseToAnyPublisher(),
             errorMessage: errorSubject.eraseToAnyPublisher()
         )
     }


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #415 

---

## 📎 Work Description 
- 일기 상세 화면에서도 주제 드롭다운을 확인할 수 있도록 기능을 추가했습니다.
- 해당 화면에서 사용하는 드롭다운의 스타일이 기존 컴포넌트와 달라, DropdownStyle enum을 분리하여 스타일을 확장했습니다.
- HomeUseCase를 활용해 해당 일기가 작성된 날짜의 주제를 조회하도록 구현했습니다.
- 주제 조회 시 yyyy-MM-dd 형식의 날짜가 필요하지만, 서버에서 연도 정보 없이 "8월 21일 목요일" 형태로 내려주는 이슈가 있어 안드로이드와 동일하게 요일 기반 역산 방식을 적용했습니다. 이 방식은 동일한 월/일/요일이 반복되는 주기(약 6~7년)에서는 연도가 정확하지 않을 수 있습니다. (민재오빠 PR 참고하였음) 해당 부분은 타임존 담당자 분이 확인해주시면 좋을 것 같습니다! 

---

## 📷 Screenshots  

| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| 일기 상세화면 | <img src="" width="250"> | <img src="https://github.com/user-attachments/assets/e08e6f17-ac97-4b8e-ae65-7ef357f347f0" width="250"> |


---

## 💬 To Reviewers  
- 꼼꼼히 확인해주시라요~ 
