### PR TITLE
[feat] att 팝업 추가 + admob 초기화 순서 변경 

### DIFF
--- a/Hilingual.xcodeproj/project.pbxproj
+++ b/Hilingual.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		E51B4C542E28DC11000B16D0 /* AppIcon.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E51B4C532E28DC11000B16D0 /* AppIcon.xcassets */; };
 		E51DB2052E1D9E8B000C2BEA /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51DB2042E1D9E8B000C2BEA /* AppConfig.swift */; };
 		E51DB2242E1E4407000C2BEA /* AppBaseURLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51DB2232E1E4407000C2BEA /* AppBaseURLProvider.swift */; };
+
 		E5C2F3952E170A01003DF6C4 /* HilingualNetwork in Frameworks */ = {isa = PBXBuildFile; productRef = E5C2F3942E170A01003DF6C4 /* HilingualNetwork */; };
 		E5C2F3992E171575003DF6C4 /* HilingualDomain in Frameworks */ = {isa = PBXBuildFile; productRef = E5C2F3982E171575003DF6C4 /* HilingualDomain */; };
 		E5C79B322E15282100E461C3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E5C79B2A2E15282100E461C3 /* LaunchScreen.storyboard */; };
@@ -48,6 +49,7 @@
 		E51DB2002E1CF7AD000C2BEA /* Hilingual.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Hilingual.entitlements; sourceTree = "<group>"; };
 		E51DB2042E1D9E8B000C2BEA /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		E51DB2232E1E4407000C2BEA /* AppBaseURLProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBaseURLProvider.swift; sourceTree = "<group>"; };
+
 		E5C2F3932E1709DC003DF6C4 /* HilingualNetwork */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = HilingualNetwork; sourceTree = "<group>"; };
 		E5C2F3972E171509003DF6C4 /* HilingualDomain */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = HilingualDomain; sourceTree = "<group>"; };
 		E5C79B0E2E15281900E461C3 /* Hilingual-Dev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Hilingual-Dev.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -138,6 +140,7 @@
 			children = (
 				E5C79B262E15282100E461C3 /* AppDelegate.swift */,
 				E5C79B2D2E15282100E461C3 /* SceneDelegate.swift */,
+
 				E5C84AC82E1538C700CBD669 /* AppDIContainer.swift */,
 				E5C79B2A2E15282100E461C3 /* LaunchScreen.storyboard */,
 				E51DB2032E1D9E47000C2BEA /* Config */,
@@ -242,6 +245,7 @@
 				E51DB2242E1E4407000C2BEA /* AppBaseURLProvider.swift in Sources */,
 				E5C84AC92E1538C700CBD669 /* AppDIContainer.swift in Sources */,
 				E51DB2052E1D9E8B000C2BEA /* AppConfig.swift in Sources */,
+
 				E5C79B342E15282100E461C3 /* AppDelegate.swift in Sources */,
 				E5C79B352E15282100E461C3 /* SceneDelegate.swift in Sources */,
 			);

--- a/Hilingual/App/AppDelegate.swift
+++ b/Hilingual/App/AppDelegate.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import FirebaseCore
-import GoogleMobileAds
 import HilingualData
 
 @main
@@ -16,7 +15,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         FirebaseApp.configure()
-        MobileAds.shared.start()
         UIFont.registerPretendardFonts()
 
 //        for key in UserDefaults.standard.dictionaryRepresentation().keys {

--- a/Hilingual/Info.plist
+++ b/Hilingual/Info.plist
@@ -27,6 +27,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>사용자의 관심사에 맞는 광고를 표시하고 광고 효과를 측정하기 위해 기기 식별자를 사용합니다. 수집된 데이터는 광고 목적으로만 활용됩니다.</string>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>

--- a/HilingualPresentation/Package.resolved
+++ b/HilingualPresentation/Package.resolved
@@ -1,6 +1,168 @@
 {
-  "originHash" : "cbf03ccd2f4bccb0fb27309b1795a0ab24b0f41ae49c44af286695b78c769bc8",
+  "originHash" : "a878aa73efad975d215bcabaf1d10a45077a989f628fcbb6cbf773f6f0b01c93",
   "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "amplitude-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/Amplitude-Swift",
+      "state" : {
+        "revision" : "b6dd7d079d20fed9e392b9dfda7a04c9d386d0a6",
+        "version" : "1.18.1"
+      }
+    },
+    {
+      "identity" : "amplitudecore-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/AmplitudeCore-Swift.git",
+      "state" : {
+        "revision" : "d9d24b79d4fcb4f1d1dcbc50ae20430afd22ebd0",
+        "version" : "1.4.5"
+      }
+    },
+    {
+      "identity" : "analytics-connector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/analytics-connector-ios.git",
+      "state" : {
+        "revision" : "4adbfe85486e6dcdcdca5fa9362097ffe5ec712b",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "46579c364d39b86ec9fb8f613e19f023700a929c",
+        "version" : "12.12.1"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "19dffda9a9caf8d86570ff846535902d8509d7bf",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "5100f946bd32778662047a823bf145c6da32d85d",
+        "version" : "12.12.1"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "0be208810d2e8b90fcd2464d1816723b47819fe7",
+        "version" : "5.2.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "kingfisher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Kingfisher.git",
+      "state" : {
+        "revision" : "c152c1915f60c51e4afa0752656993ee5b3c63db",
+        "version" : "8.8.1"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "lottie-spm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/airbnb/lottie-spm.git",
+      "state" : {
+        "revision" : "69faaefa7721fba9e434a52c16adf4329c9084db",
+        "version" : "4.6.0"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
     {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",

--- a/HilingualPresentation/Sources/Presentation/Splash/SplashViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Splash/SplashViewController.swift
@@ -5,7 +5,9 @@
 //  Created by 성현주 on 7/15/25.
 //
 
+import AppTrackingTransparency
 import Combine
+import GoogleMobileAds
 import UIKit
 import FirebaseCore
 import FirebaseRemoteConfig
@@ -19,6 +21,10 @@ public final class SplashViewController: BaseUIViewController<SplashViewModel> {
     // MARK: - Combine
 
     private let viewDidAppearSubject = PassthroughSubject<Void, Never>()
+
+    // MARK: - Ad
+
+    private var didInitializeMobileAds = false
 
     // MARK: - Firebase Remote Config
     private let remoteConfig = RemoteConfig.remoteConfig()
@@ -37,6 +43,30 @@ public final class SplashViewController: BaseUIViewController<SplashViewModel> {
 
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        requestTrackingAuthorizationAndInitializeAds()
+    }
+
+    // MARK: - ATT & AdMob
+
+    private func requestTrackingAuthorizationAndInitializeAds() {
+        guard !didInitializeMobileAds else { return }
+
+        if #available(iOS 14, *),
+           ATTrackingManager.trackingAuthorizationStatus == .notDetermined {
+            ATTrackingManager.requestTrackingAuthorization { [weak self] _ in
+                Task { @MainActor in
+                    self?.initializeMobileAdsAndProceed()
+                }
+            }
+        } else {
+            initializeMobileAdsAndProceed()
+        }
+    }
+
+    private func initializeMobileAdsAndProceed() {
+        guard !didInitializeMobileAds else { return }
+        didInitializeMobileAds = true
+        MobileAds.shared.start()
         checkRemoteConfigVersion()
     }
 


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #420

---

## 📎 Work Description 
- 스플래시 화면에서 ATT 권한요청 팝업을 호출했습니다.
- 앱델리게이트에 import AppTrackingTransparency, import GoogleMobileAds 추가했습니다 ATT 응답 후 MobileAds.shared.start() -> checkRemoteConfigVersion() 순서로 진행되게해서 IDFA를 admob에서 활용가능하도록 초기화 순서를 변경했습니다

---

## 📷 Screenshots  

<img width="300" height="600" alt="IMG_6012" src="https://github.com/user-attachments/assets/d823b728-95cb-4b11-ac7d-9858807f5244" />


| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| A 기능 | <img src="" width="250"> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
