### PR TITLE
[Feat] 닉네임 변경 ui 추가 + 서버 api 연동 

### DIFF
--- a/Hilingual/App/AppDIContainer.swift
+++ b/Hilingual/App/AppDIContainer.swift
@@ -177,6 +177,14 @@ final class AppDIContainer: ViewControllerFactory {
         return EditProfileViewController(viewModel: makeEditProfileViewModel(), diContainer: self)
     }
 
+    public func makeNicknameEditViewController(currentNickname: String) -> NicknameEditViewController {
+        return NicknameEditViewController(
+            viewModel: makeNicknameEditViewModel(currentNickname: currentNickname),
+            diContainer: self,
+            currentNickname: currentNickname
+        )
+    }
+
     public func makeBlockUserViewController() -> BlockUserViewController {
         return BlockUserViewController(viewModel: makeBlockUserViewModel(), diContainer: self)
     }
@@ -817,5 +825,13 @@ extension AppDIContainer {
 
     private func makeEditProfileViewModel() -> EditProfileViewModel {
         return EditProfileViewModel(fetchUserProfileUseCase: makefetchUserProfileUseCase(), uploadImageUseCase: makeUploadImageUseCase(), mypageUseCase: makeMypageUseCase())
+    }
+
+    private func makeNicknameEditViewModel(currentNickname: String) -> NicknameEditViewModel {
+        return NicknameEditViewModel(
+            currentNickname: currentNickname,
+            onBoardingUseCase: makeOnBoardingUseCase(),
+            userProfileUseCase: makefetchUserProfileUseCase()
+        )
     }
 }

--- a/HilingualData/Sources/HilingualData/Repository/DefaultUserProfileRepository.swift
+++ b/HilingualData/Sources/HilingualData/Repository/DefaultUserProfileRepository.swift
@@ -25,4 +25,8 @@ public final class DefaultUserProfileRepository: UserProfileRepository {
     public func updateProfileImage(fileKey: String) -> AnyPublisher<Void, Error> {
            service.updateProfileImage(fileKey: fileKey)
     }
+
+    public func updateNickname(nickname: String) -> AnyPublisher<Void, Error> {
+        service.updateNickname(nickname: nickname)
+    }
 }

--- a/HilingualDomain/Sources/HilingualDomain/Interface/Repository/UserProfileRepository.swift
+++ b/HilingualDomain/Sources/HilingualDomain/Interface/Repository/UserProfileRepository.swift
@@ -10,4 +10,5 @@ import Combine
 public protocol UserProfileRepository {
     func fetchMyProfile() -> AnyPublisher<UserProfileEntity, Error>
     func updateProfileImage(fileKey: String) -> AnyPublisher<Void, Error>
+    func updateNickname(nickname: String) -> AnyPublisher<Void, Error>
 }

--- a/HilingualDomain/Sources/HilingualDomain/UseCase/FetchUserProfileUseCase.swift
+++ b/HilingualDomain/Sources/HilingualDomain/UseCase/FetchUserProfileUseCase.swift
@@ -10,6 +10,7 @@ import Combine
 public protocol FetchUserProfileUseCase {
     func fetchMyProfile() -> AnyPublisher<UserProfileEntity, Error>
     func updateProfileImage(fileKey: String) -> AnyPublisher<Void, Error>
+    func updateNickname(nickname: String) -> AnyPublisher<Void, Error>
 }
 
 public final class DefaultFetchUserProfileUseCase: FetchUserProfileUseCase {
@@ -25,5 +26,9 @@ public final class DefaultFetchUserProfileUseCase: FetchUserProfileUseCase {
 
     public func updateProfileImage(fileKey: String) -> AnyPublisher<Void, Error> {
         return repository.updateProfileImage(fileKey: fileKey)
+    }
+
+    public func updateNickname(nickname: String) -> AnyPublisher<Void, Error> {
+        return repository.updateNickname(nickname: nickname)
     }
 }

--- a/HilingualNetwork/Sources/HilingualNetwork/API/MypageAPI.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/API/MypageAPI.swift
@@ -11,6 +11,7 @@ import Moya
 public enum MypageAPI {
     case fetchMyProfile
     case updateProfileImage(request: ProfileImageRequestDTO)
+    case updateNickname(request: NicknameRequestDTO)
 }
 
 extension MypageAPI: BaseTargetType {
@@ -21,6 +22,8 @@ extension MypageAPI: BaseTargetType {
             return "/users/mypage/info"
         case .updateProfileImage:
             return "/users/mypage/profileImg"
+        case .updateNickname:
+            return "/users/profile/nickname"
         }
     }
 
@@ -28,7 +31,7 @@ extension MypageAPI: BaseTargetType {
         switch self {
         case .fetchMyProfile:
             return .get
-        case .updateProfileImage:
+        case .updateProfileImage, .updateNickname:
             return .patch
         }
     }
@@ -38,6 +41,8 @@ extension MypageAPI: BaseTargetType {
         case .fetchMyProfile:
             return .requestPlain
         case .updateProfileImage(let request):
+            return .requestJSONEncodable(request)
+        case .updateNickname(let request):
             return .requestJSONEncodable(request)
         }
     }

--- a/HilingualNetwork/Sources/HilingualNetwork/DTO/NicknameRequestDTO.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/DTO/NicknameRequestDTO.swift
@@ -1,0 +1,16 @@
+//
+//  NicknameRequestDTO.swift
+//  HilingualNetwork
+//
+//  Created by 성현주 on 5/16/26.
+//
+
+import Foundation
+
+public struct NicknameRequestDTO: Encodable {
+    public let nickname: String
+
+    public init(nickname: String) {
+        self.nickname = nickname
+    }
+}

--- a/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultUserProfileService.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultUserProfileService.swift
@@ -11,6 +11,7 @@ import Moya
 public protocol UserProfileService {
     func fetchMyProfile() -> AnyPublisher<UserProfileResponseDTO, Error>
     func updateProfileImage(fileKey: String) -> AnyPublisher<Void, Error>
+    func updateNickname(nickname: String) -> AnyPublisher<Void, Error>
 }
 
 public final class DefaultUserProfileService: BaseService<MypageAPI>, UserProfileService {
@@ -26,6 +27,14 @@ public final class DefaultUserProfileService: BaseService<MypageAPI>, UserProfil
     public func updateProfileImage(fileKey: String) -> AnyPublisher<Void, Error> {
         let dto = ProfileImageRequestDTO(fileKey: fileKey)
         return requestPlain(.updateProfileImage(request: dto))
+            .map { _ in () }
+            .mapError { $0 as Error }
+            .eraseToAnyPublisher()
+    }
+
+    public func updateNickname(nickname: String) -> AnyPublisher<Void, Error> {
+        let dto = NicknameRequestDTO(nickname: nickname)
+        return requestPlain(.updateNickname(request: dto))
             .map { _ in () }
             .mapError { $0 as Error }
             .eraseToAnyPublisher()

--- a/HilingualPresentation/Sources/Presentation/Common/Components/CTAButton.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/CTAButton.swift
@@ -27,8 +27,8 @@ final class CTAButton: UIButton {
     
     override var isEnabled: Bool {
         didSet {
-            if autoBackground {
-                updateBackgroundColor()
+            if autoBackground, oldValue != isEnabled {
+                updateBackgroundColor(animated: window != nil)
             }
         }
     }
@@ -43,7 +43,7 @@ final class CTAButton: UIButton {
         self.isEnabled = autoBackground ? false : true
         
         if autoBackground {
-            updateBackgroundColor()
+            updateBackgroundColor(animated: false)
         } else {
             backgroundColor = .hilingualBlack
         }
@@ -95,8 +95,20 @@ final class CTAButton: UIButton {
     
     // MARK: - Private Methods
     
-    private func updateBackgroundColor() {
-        backgroundColor = isEnabled ? .hilingualBlack : .gray300
+    private func updateBackgroundColor(animated: Bool = false) {
+        let nextColor: UIColor = isEnabled ? .hilingualBlack : .gray300
+        guard animated else {
+            backgroundColor = nextColor
+            return
+        }
+
+        UIView.animate(
+            withDuration: 0.25,
+            delay: 0,
+            options: [.allowUserInteraction, .beginFromCurrentState]
+        ) {
+            self.backgroundColor = nextColor
+        }
     }
     
     // MARK: - Public Methods

--- a/HilingualPresentation/Sources/Presentation/Common/Components/nickNameTextField.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/nickNameTextField.swift
@@ -12,7 +12,7 @@ final class nickNameTextField: BaseUIView {
 
     public enum State {
         case normal
-        case error(String)
+        case error(String, shouldShake: Bool = true)
         case success(String)
         case wait
     }
@@ -28,6 +28,8 @@ final class nickNameTextField: BaseUIView {
     var text: String {
         return textField.text ?? ""
     }
+
+    private var isShowingError = false
 
     // MARK: - UI Components
 
@@ -129,23 +131,30 @@ final class nickNameTextField: BaseUIView {
     func updateState(_ state: State) {
         switch state {
         case .normal:
+            isShowingError = false
             textField.layer.borderColor = UIColor.clear.cgColor
             messageLabel.text = ""
             stopLoading()
 
-        case .error(let message):
+        case .error(let message, let shouldShake):
+            if shouldShake && !isShowingError {
+                shakeTextField()
+            }
+            isShowingError = true
             textField.layer.borderColor = UIColor.alertRed.cgColor
             messageLabel.text = message
             messageLabel.textColor = .alertRed
             stopLoading()
 
         case .success(let message):
+            isShowingError = false
             textField.layer.borderColor = UIColor.clear.cgColor
             messageLabel.text = message
             messageLabel.textColor = .hilingualBlue
             stopLoading()
 
         case .wait:
+            isShowingError = false
             textField.layer.borderColor = UIColor.clear.cgColor
             messageLabel.text = ""
             startLoading()
@@ -189,6 +198,14 @@ final class nickNameTextField: BaseUIView {
 
     private func updateCharacterCount() {
         characterCountLabel.text = "\(text.count)/\(maxLength)"
+    }
+
+    private func shakeTextField() {
+        let animation = CAKeyframeAnimation(keyPath: "transform.translation.x")
+        animation.timingFunction = CAMediaTimingFunction(name: .linear)
+        animation.duration = 0.35
+        animation.values = [-6, 6, -4, 4, -2, 2, 0]
+        textField.layer.add(animation, forKey: "errorShake")
     }
 
     private func addTextPadding() {

--- a/HilingualPresentation/Sources/Presentation/Common/Components/nickNameTextField.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/nickNameTextField.swift
@@ -119,6 +119,13 @@ final class nickNameTextField: BaseUIView {
         )
     }
 
+    func setText(_ text: String) {
+        let noSpaces = text.replacingOccurrences(of: " ", with: "")
+        let trimmed = noSpaces.count > maxLength ? String(noSpaces.prefix(maxLength)) : noSpaces
+        textField.attributedText = .pretendard(.body_m_16, text: trimmed)
+        updateCharacterCount()
+    }
+
     func updateState(_ state: State) {
         switch state {
         case .normal:
@@ -205,9 +212,6 @@ final class nickNameTextField: BaseUIView {
     @objc
     private func textDidChange() {
         let current = textField.text ?? ""
-        let noSpaces = current.replacingOccurrences(of: " ", with: "")
-        let trimmed = noSpaces.count > maxLength ? String(noSpaces.prefix(maxLength)) : noSpaces
-        textField.attributedText = .pretendard(.body_m_16, text: trimmed)
-        updateCharacterCount()
+        setText(current)
     }
 }

--- a/HilingualPresentation/Sources/Presentation/Common/Factory/ViewControllerFactory.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Factory/ViewControllerFactory.swift
@@ -41,6 +41,7 @@ public protocol ViewControllerFactory {
         userId: Int64
     ) -> FeedProfileViewController
     func makeEditProfileViewController() -> EditProfileViewController
+    func makeNicknameEditViewController(currentNickname: String) -> NicknameEditViewController
     func makeBlockUserViewController() -> BlockUserViewController
     func makeNotificationSettingViewController() -> NotificationSettingViewController
 }

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/EditProfileView.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/EditProfileView.swift
@@ -12,8 +12,9 @@ final class EditProfileView: BaseUIView {
 
     // MARK: - Public Callback
 
-     var onSelectDefaultImage: (() -> Void)?
-     var onSelectGallery: (() -> Void)?
+    var onSelectDefaultImage: (() -> Void)?
+    var onSelectGallery: (() -> Void)?
+    var onNicknameTapped: (() -> Void)?
 
     // MARK: - UI Components
 
@@ -31,7 +32,7 @@ final class EditProfileView: BaseUIView {
 
     let profileImageView = EditableProfileImageView()
 
-    let nicknameRow = ProfileRow(title: "닉네임", value: "sereal")
+    let nicknameRow = ProfileRow(title: "닉네임", value: "sereal", type: .editable)
     let socialRow = ProfileRow(title: "연결된 소셜 계정", value: "애플 로그인")
 
     let withdrawButton: UIButton = {
@@ -54,6 +55,7 @@ final class EditProfileView: BaseUIView {
         backgroundColor = .white
         addSubviews(backButton, profileImageView, nicknameRow, socialRow, withdrawButton, modal)
         configureModal()
+        configureNicknameRow()
     }
 
     override func setLayout() {
@@ -106,6 +108,16 @@ final class EditProfileView: BaseUIView {
                 ]
             )
         }
+
+    private func configureNicknameRow() {
+        nicknameRow.isUserInteractionEnabled = true
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(nicknameRowTapped))
+        nicknameRow.addGestureRecognizer(tapGesture)
+    }
+
+    @objc private func nicknameRowTapped() {
+        onNicknameTapped?()
+    }
 }
 
 extension EditProfileView {

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/EditProfileViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/EditProfileViewController.swift
@@ -23,6 +23,7 @@ public final class EditProfileViewController: BaseUIViewController<EditProfileVi
     }()
 
     private let withdrawTappedSubject = PassthroughSubject<Void, Never>()
+    private var currentNickname: String?
 
     // MARK: - Life Cycle
 
@@ -65,6 +66,7 @@ public final class EditProfileViewController: BaseUIViewController<EditProfileVi
             .receive(on: RunLoop.main)
             .sink { [weak self] profile in
                 guard let profile else { return }
+                self?.currentNickname = profile.nickname
                 self?.editProfileView.configure(
                     profileImageURL: profile.profileImg,
                     nickname: profile.nickname,
@@ -108,6 +110,10 @@ public final class EditProfileViewController: BaseUIViewController<EditProfileVi
         editProfileView.onSelectGallery = { [weak self] in
             self?.presentImagePicker()
         }
+
+        editProfileView.onNicknameTapped = { [weak self] in
+            self?.pushNicknameEditViewController()
+        }
     }
 
     // MARK: - Actions
@@ -148,6 +154,16 @@ public final class EditProfileViewController: BaseUIViewController<EditProfileVi
         let picker = PHPickerViewController(configuration: pickerConfig)
         picker.delegate = self
         present(picker, animated: true)
+    }
+
+    private func pushNicknameEditViewController() {
+        guard let currentNickname else { return }
+        let nicknameEditVC = diContainer.makeNicknameEditViewController(currentNickname: currentNickname)
+        nicknameEditVC.onNicknameChanged = { [weak self] nickname in
+            self?.currentNickname = nickname
+            self?.editProfileView.nicknameRow.setValue(value: nickname)
+        }
+        navigationController?.pushViewController(nicknameEditVC, animated: true)
     }
 }
 

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditView.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditView.swift
@@ -51,7 +51,7 @@ final class NicknameEditView: BaseUIView {
 
         changeButton.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().inset(50)
+            $0.bottom.equalTo(keyboardLayoutGuide.snp.top).offset(-16)
         }
     }
 

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditView.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditView.swift
@@ -1,0 +1,61 @@
+//
+//  NicknameEditView.swift
+//  HilingualPresentation
+//
+//  Created by 성현주 on 5/16/26.
+//
+
+import UIKit
+import SnapKit
+
+final class NicknameEditView: BaseUIView {
+
+    // MARK: - UI Components
+
+    let nicknameLabel: UILabel = {
+        let label = UILabel()
+        label.attributedText = .pretendard(.body_m_16, text: "닉네임")
+        label.textColor = .hilingualBlack
+        return label
+    }()
+
+    let nicknameTextField: nickNameTextField = {
+        let textField = nickNameTextField()
+        textField.setPlaceholder("한글, 영문, 숫자 조합만 가능")
+        return textField
+    }()
+
+    let changeButton: CTAButton = {
+        CTAButton(style: .TextButton("변경하기"), autoBackground: true)
+    }()
+
+    private lazy var nicknameStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [nicknameLabel, nicknameTextField])
+        stack.axis = .vertical
+        stack.spacing = 4
+        return stack
+    }()
+
+    // MARK: - Setup
+
+    override func setUI() {
+        backgroundColor = .white
+        addSubviews(nicknameStackView, changeButton)
+    }
+
+    override func setLayout() {
+        nicknameStackView.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide.snp.top).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+
+        changeButton.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().inset(50)
+        }
+    }
+
+    func configure(nickname: String) {
+        nicknameTextField.setText(nickname)
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditViewController.swift
@@ -39,6 +39,11 @@ public final class NicknameEditViewController: BaseUIViewController<NicknameEdit
         nicknameSubject.send(currentNickname)
     }
 
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        nicknameEditView.nicknameTextField.textField.becomeFirstResponder()
+    }
+
     // MARK: - Setup
 
     public override func setUI() {

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditViewController.swift
@@ -1,0 +1,113 @@
+//
+//  NicknameEditViewController.swift
+//  HilingualPresentation
+//
+//  Created by 성현주 on 5/16/26.
+//
+
+import Combine
+import Foundation
+import UIKit
+
+public final class NicknameEditViewController: BaseUIViewController<NicknameEditViewModel> {
+
+    // MARK: - Properties
+
+    public var onNicknameChanged: ((String) -> Void)?
+
+    private let nicknameEditView = NicknameEditView()
+    private let currentNickname: String
+    private let nicknameSubject = PassthroughSubject<String, Never>()
+    private let changeTappedSubject = PassthroughSubject<Void, Never>()
+
+    // MARK: - Init
+
+    public init(
+        viewModel: NicknameEditViewModel,
+        diContainer: any ViewControllerFactory,
+        currentNickname: String
+    ) {
+        self.currentNickname = currentNickname
+        super.init(viewModel: viewModel, diContainer: diContainer)
+    }
+
+    // MARK: - Life Cycle
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        nicknameEditView.configure(nickname: currentNickname)
+        nicknameSubject.send(currentNickname)
+    }
+
+    // MARK: - Setup
+
+    public override func setUI() {
+        super.setUI()
+        view.addSubview(nicknameEditView)
+    }
+
+    public override func setLayout() {
+        nicknameEditView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+
+    public override func navigationType() -> NavigationType? {
+        .backTitle("닉네임 변경")
+    }
+
+    public override func addTarget() {
+        nicknameEditView.nicknameTextField.textField.addTarget(self, action: #selector(nicknameDidChange), for: .editingChanged)
+        nicknameEditView.changeButton.addTarget(self, action: #selector(changeTapped), for: .touchUpInside)
+    }
+
+    // MARK: - Bind
+
+    public override func bind(viewModel: NicknameEditViewModel) {
+        let input = NicknameEditViewModel.Input(
+            nicknameChanged: nicknameSubject.eraseToAnyPublisher(),
+            changeTapped: changeTappedSubject.eraseToAnyPublisher()
+        )
+
+        let output = viewModel.transform(input: input)
+
+        output.nicknameState
+            .receive(on: RunLoop.main)
+            .sink { [weak self] state in
+                self?.nicknameEditView.nicknameTextField.updateState(state)
+            }
+            .store(in: &cancellables)
+
+        output.changeButtonEnabled
+            .receive(on: RunLoop.main)
+            .sink { [weak self] isEnabled in
+                self?.nicknameEditView.changeButton.isEnabled = isEnabled
+            }
+            .store(in: &cancellables)
+
+        output.updateSuccess
+            .receive(on: RunLoop.main)
+            .sink { [weak self] nickname in
+                self?.onNicknameChanged?(nickname)
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .store(in: &cancellables)
+
+        output.updateError
+            .receive(on: RunLoop.main)
+            .sink { error in
+                print("닉네임 변경 실패: \(error)")
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Actions
+
+    @objc private func nicknameDidChange() {
+        nicknameSubject.send(nicknameEditView.nicknameTextField.text)
+    }
+
+    @objc private func changeTapped() {
+        changeTappedSubject.send(())
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditViewModel.swift
@@ -94,7 +94,7 @@ public final class NicknameEditViewModel: BaseViewModel {
         case .empty:
             nicknameStateSubject.send(.normal)
         case .tooShort:
-            nicknameStateSubject.send(.error("최소 2글자 이상 입력해주세요."))
+            nicknameStateSubject.send(.error("최소 2글자 이상 입력해주세요.", shouldShake: false))
         case .containsInvalidCharacters:
             nicknameStateSubject.send(.error("특수문자, 이모지는 사용이 불가능해요."))
         case .valid:

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/NicknameEdit/NicknameEditViewModel.swift
@@ -1,0 +1,149 @@
+//
+//  NicknameEditViewModel.swift
+//  HilingualPresentation
+//
+//  Created by 성현주 on 5/16/26.
+//
+
+import Combine
+import Foundation
+import HilingualDomain
+
+public final class NicknameEditViewModel: BaseViewModel {
+
+    // MARK: - Input / Output
+
+    public struct Input {
+        let nicknameChanged: AnyPublisher<String, Never>
+        let changeTapped: AnyPublisher<Void, Never>
+    }
+
+    public struct Output {
+        let nicknameState: AnyPublisher<nickNameTextField.State, Never>
+        let changeButtonEnabled: AnyPublisher<Bool, Never>
+        let updateSuccess: AnyPublisher<String, Never>
+        let updateError: AnyPublisher<Error, Never>
+    }
+
+    // MARK: - Properties
+
+    private let currentNickname: String
+    private let onBoardingUseCase: OnBoardingUseCase
+    private let userProfileUseCase: FetchUserProfileUseCase
+    private let nicknameStateSubject = PassthroughSubject<nickNameTextField.State, Never>()
+    private let changeButtonEnabledSubject = CurrentValueSubject<Bool, Never>(false)
+    private let updateSuccessSubject = PassthroughSubject<String, Never>()
+    private let updateErrorSubject = PassthroughSubject<Error, Never>()
+    private var latestNickname: String = ""
+    private var duplicateCheckWorkItem: DispatchWorkItem?
+    private var duplicateCheckCancellable: AnyCancellable?
+
+    // MARK: - Init
+
+    public init(
+        currentNickname: String,
+        onBoardingUseCase: OnBoardingUseCase,
+        userProfileUseCase: FetchUserProfileUseCase
+    ) {
+        self.currentNickname = currentNickname
+        self.onBoardingUseCase = onBoardingUseCase
+        self.userProfileUseCase = userProfileUseCase
+        self.latestNickname = currentNickname
+    }
+
+    // MARK: - Transform
+
+    public func transform(input: Input) -> Output {
+        input.nicknameChanged
+            .sink { [weak self] nickname in
+                self?.nicknameDidChange(nickname)
+            }
+            .store(in: &cancellables)
+
+        input.changeTapped
+            .sink { [weak self] in
+                self?.updateNickname()
+            }
+            .store(in: &cancellables)
+
+        return Output(
+            nicknameState: nicknameStateSubject.eraseToAnyPublisher(),
+            changeButtonEnabled: changeButtonEnabledSubject.eraseToAnyPublisher(),
+            updateSuccess: updateSuccessSubject.eraseToAnyPublisher(),
+            updateError: updateErrorSubject.eraseToAnyPublisher()
+        )
+    }
+
+    // MARK: - Private Methods
+
+    private func nicknameDidChange(_ text: String) {
+        let nickname = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard nickname != latestNickname else { return }
+
+        latestNickname = nickname
+        changeButtonEnabledSubject.send(false)
+        duplicateCheckWorkItem?.cancel()
+        duplicateCheckCancellable?.cancel()
+
+        if nickname == currentNickname {
+            nicknameStateSubject.send(.normal)
+            return
+        }
+
+        switch onBoardingUseCase.validate(nickname) {
+        case .empty:
+            nicknameStateSubject.send(.normal)
+        case .tooShort:
+            nicknameStateSubject.send(.error("최소 2글자 이상 입력해주세요."))
+        case .containsInvalidCharacters:
+            nicknameStateSubject.send(.error("특수문자, 이모지는 사용이 불가능해요."))
+        case .valid:
+            nicknameStateSubject.send(.wait)
+            scheduleDuplicateCheck(for: nickname)
+        }
+    }
+
+    private func scheduleDuplicateCheck(for nickname: String) {
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.checkDuplicate(nickname)
+        }
+
+        duplicateCheckWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: workItem)
+    }
+
+    private func checkDuplicate(_ nickname: String) {
+        duplicateCheckCancellable = onBoardingUseCase.checkDuplicate(nickname)
+            .sink { [weak self] isAvailable, message in
+                guard let self, nickname == latestNickname else { return }
+
+                if isAvailable {
+                    nicknameStateSubject.send(.success(message ?? "사용 가능한 닉네임이에요."))
+                    changeButtonEnabledSubject.send(true)
+                } else {
+                    nicknameStateSubject.send(.error(message ?? "이미 사용중인 닉네임이에요."))
+                    changeButtonEnabledSubject.send(false)
+                }
+            }
+    }
+
+    private func updateNickname() {
+        guard changeButtonEnabledSubject.value else { return }
+        requestNicknameUpdate(latestNickname)
+    }
+
+    private func requestNicknameUpdate(_ nickname: String) {
+        userProfileUseCase.updateNickname(nickname: nickname)
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    if case .failure(let error) = completion {
+                        self?.updateErrorSubject.send(error)
+                    }
+                },
+                receiveValue: { [weak self] in
+                    self?.updateSuccessSubject.send(nickname)
+                }
+            )
+            .store(in: &cancellables)
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/ProfileRow.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/ProfileRow.swift
@@ -10,6 +10,15 @@ import SnapKit
 
 final class ProfileRow: UIView {
 
+    enum RowType {
+        case none
+        case editable
+    }
+
+    // MARK: - Properties
+
+    private let type: RowType
+
     // MARK: - UI Components
 
     private let titleLabel: UILabel = {
@@ -27,9 +36,34 @@ final class ProfileRow: UIView {
         return label
     }()
 
+    private let editImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "ic_pen_24_ios", in: .module, compatibleWith: nil)
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private lazy var trailingStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: trailingViews)
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = 8
+        return stackView
+    }()
+
+    private var trailingViews: [UIView] {
+        switch type {
+        case .none:
+            return [valueLabel]
+        case .editable:
+            return [valueLabel, editImageView]
+        }
+    }
+
     // MARK: - Init
 
-    init(title: String, value: String) {
+    init(title: String, value: String, type: RowType = .none) {
+        self.type = type
         super.init(frame: .zero)
         titleLabel.text = title
         valueLabel.text = value
@@ -48,18 +82,25 @@ final class ProfileRow: UIView {
         layer.cornerRadius = 8
         layer.borderWidth = 1
         layer.borderColor = UIColor.gray200.cgColor
-        addSubviews(titleLabel, valueLabel)
+        addSubviews(titleLabel, trailingStackView)
     }
 
     private func setupLayout() {
         titleLabel.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(16)
+            $0.leading.equalToSuperview().inset(20)
             $0.centerY.equalToSuperview()
         }
 
-        valueLabel.snp.makeConstraints {
+        if case .editable = type {
+            editImageView.snp.makeConstraints {
+                $0.size.equalTo(24)
+            }
+        }
+
+        trailingStackView.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
+            $0.leading.greaterThanOrEqualTo(titleLabel.snp.trailing).offset(12)
         }
     }
 

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/ProfileRow.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/ProfileRow.swift
@@ -38,7 +38,7 @@ final class ProfileRow: UIView {
 
     private let editImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(named: "ic_pen_24_ios", in: .module, compatibleWith: nil)?
+        imageView.image = UIImage(resource: .icPen24Ios)
             .withRenderingMode(.alwaysTemplate)
         imageView.tintColor = .gray300
         imageView.contentMode = .scaleAspectFit
@@ -102,7 +102,7 @@ final class ProfileRow: UIView {
         trailingStackView.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
-            $0.leading.greaterThanOrEqualTo(titleLabel.snp.trailing).offset(12)
+            $0.leading.equalTo(titleLabel.snp.trailing).offset(12)
         }
     }
 

--- a/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/ProfileRow.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/EditProfile/ProfileRow.swift
@@ -8,16 +8,16 @@
 import UIKit
 import SnapKit
 
-final class ProfileRow: UIView {
+enum ProfileRowType {
+    case none
+    case editable
+}
 
-    enum RowType {
-        case none
-        case editable
-    }
+final class ProfileRow: UIView {
 
     // MARK: - Properties
 
-    private let type: RowType
+    private let type: ProfileRowType
 
     // MARK: - UI Components
 
@@ -38,7 +38,9 @@ final class ProfileRow: UIView {
 
     private let editImageView: UIImageView = {
         let imageView = UIImageView()
-        imageView.image = UIImage(named: "ic_pen_24_ios", in: .module, compatibleWith: nil)
+        imageView.image = UIImage(named: "ic_pen_24_ios", in: .module, compatibleWith: nil)?
+            .withRenderingMode(.alwaysTemplate)
+        imageView.tintColor = .gray300
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
@@ -62,7 +64,7 @@ final class ProfileRow: UIView {
 
     // MARK: - Init
 
-    init(title: String, value: String, type: RowType = .none) {
+    init(title: String, value: String, type: ProfileRowType = .none) {
         self.type = type
         super.init(frame: .zero)
         titleLabel.text = title

--- a/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageView.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageView.swift
@@ -72,7 +72,7 @@ final class MypageView: BaseUIView {
 
     let editButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(named: "ic_pen_24_ios", in: .module, compatibleWith: nil), for: .normal)
+        button.setImage(UIImage(resource: .icPen24Ios), for: .normal)
         button.tintColor = .gray400
         return button
     }()


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #427

---

## 📎 Work Description 
- 닉네임 변경 기능을 구현했습니다. 
- 닉네임 변경 ui와 마이페이지에서 연결되는 플로우를 구현했습니다
- 닉네임 변경 뷰에서 기종에 온보딩에서 사용하던 닉네임 중복로직을 리펙토링했습니다 
- 닉네임 변경 신규 api를 연동했습니다 
- 키보드에 의해 가려지는 cta버튼을 키보드 위로 이동하도록 했습니다
- 중복이거나, 부적절한 닉네임경우 텍스트필드가 shake하도록해 유저가 더 잘 인지할수있는 마이크로 인터렉션을 추가해봤습니다!


---

## 📷 Screenshots  

| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| A 기능 | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-05-17 at 01 02 54" src="https://github.com/user-attachments/assets/fb01469e-8606-4b8c-b414-9c83c1aa182b" /> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |


---

## 💬 To Reviewers  
- 아직 서버 배포가 안되어 서버 연동 테스트는 못해 방향성 싱크를 위한 draft PR로 올립니다! 5/17 중으로 서버 배포되면 서버연결 확인후 PR로 변경하겠습니다! 
