### PR TITLE
[fix] 전면광고 오류 개선

### DIFF
--- a/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryWriting/DiaryWritingViewController.swift
@@ -223,6 +223,7 @@ public final class DiaryWritingViewController: BaseUIViewController<DiaryWriting
 
         let loadingVC = diContainer.makeLoadingViewController()
         loadingVC.viewModel?.postDiary(originalText: text, date: dateString, imageFile: imageData)
+        loadingVC.preloadAd()
         navigationController?.pushViewController(loadingVC, animated: true)
     }
 

--- a/HilingualPresentation/Sources/Presentation/Loading/LoadingViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Loading/LoadingViewController.swift
@@ -20,6 +20,8 @@ public final class LoadingViewController: BaseUIViewController<LoadingViewModel>
     private let loadingView = LoadingView()
     private var interstitial: InterstitialAd?
     
+    private var adLoadTimestamp: Date?
+    
     private let retryTappedSubject = PassthroughSubject<Void, Never>()
     private let closeTappedSubject = PassthroughSubject<Void, Never>()
     
@@ -31,7 +33,6 @@ public final class LoadingViewController: BaseUIViewController<LoadingViewModel>
         super.viewDidLoad()
         addTarget()
         setStyle()
-        loadInterstitialAd()
     }
     
     public override func viewWillAppear(_ animated: Bool) {
@@ -125,20 +126,25 @@ public final class LoadingViewController: BaseUIViewController<LoadingViewModel>
     
     // MARK: - Navigation
     
-    private func loadInterstitialAd() {
-        InterstitialAd.load(
-            with: Bundle.main.infoDictionary?["AD_INTERSTITIAL_UNIT_ID"] as? String ?? "",
-            request: Request()
-        ) { [weak self] ad, error in
-            guard let self else { return }
-            if let error {
-                print("Interstitial load failed: \(error)")
+    public func preloadAd() {
+        if let _ = interstitial, isAdValid() { return }
+        
+        let unitID = Bundle.main.infoDictionary?["AD_INTERSTITIAL_UNIT_ID"] as? String ?? ""
+        
+        InterstitialAd.load(with: unitID, request: Request()) { [weak self] ad, error in
+            guard let self = self else { return }
+            
+            if let error = error {
+                print("❌ 광고 로드 실패: \(error.localizedDescription)")
                 self.retryLoadingAdIfNeeded()
                 return
             }
+            
             self.adLoadRetryCount = 0
             self.interstitial = ad
             self.interstitial?.fullScreenContentDelegate = self
+            self.adLoadTimestamp = Date()
+            print("✅ 광고 로드 완료")
             
             if let pendingDiaryId = self.pendingDiaryId, let ad = ad {
                 self.pendingDiaryId = nil
@@ -147,9 +153,15 @@ public final class LoadingViewController: BaseUIViewController<LoadingViewModel>
             }
         }
     }
+    
+    private func isAdValid() -> Bool {
+        guard let timestamp = adLoadTimestamp else { return false }
+        return Date().timeIntervalSince(timestamp) < 3600
+    }
+    
     private func retryLoadingAdIfNeeded() {
         guard adLoadRetryCount < Self.maxAdRetryCount else {
-            print("Ad load failed after \(Self.maxAdRetryCount) retries")
+            print("🚨 재시도 횟수 초과 (\(Self.maxAdRetryCount)회) -> 광고 없이 화면 이동")
             if let pendingDiaryId = self.pendingDiaryId {
                 self.pendingDiaryId = nil
                 DispatchQueue.main.async {
@@ -161,24 +173,28 @@ public final class LoadingViewController: BaseUIViewController<LoadingViewModel>
         
         let delay = pow(2.0, Double(adLoadRetryCount))
         adLoadRetryCount += 1
+        print("🔄 광고 재시도 예약: \(delay)초 후 로드 (시도 \(adLoadRetryCount)/\(Self.maxAdRetryCount))")
         
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            self?.loadInterstitialAd()
+            self?.preloadAd()
         }
     }
-
+    
     private func goToNextView() {
         viewModel?.diaryIdPublisher
             .compactMap { $0 }
             .first()
             .sink { [weak self] (diaryId: Int) in
-                guard let self else { return }
-                if let ad = self.interstitial {
+                guard let self = self else { return }
+                
+                if let ad = self.interstitial, self.isAdValid() {
                     self.currentDiaryId = diaryId
                     ad.present(from: self)
-                } else if self.adLoadRetryCount < Self.maxAdRetryCount {
+                }
+                else if self.adLoadRetryCount < Self.maxAdRetryCount {
                     self.pendingDiaryId = diaryId
-                } else {
+                }
+                else {
                     self.currentDiaryId = diaryId
                     self.pushDiaryDetail(diaryId: diaryId)
                 }
@@ -202,6 +218,8 @@ public final class LoadingViewController: BaseUIViewController<LoadingViewModel>
 extension LoadingViewController: FullScreenContentDelegate {
     public func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
         interstitial = nil
+        adLoadTimestamp = nil
+        
         guard let diaryId = currentDiaryId else { return }
         viewModel?.patchAdWatch(diaryId: diaryId)
         pushDiaryDetail(diaryId: diaryId)
@@ -209,6 +227,8 @@ extension LoadingViewController: FullScreenContentDelegate {
     
     public func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
         interstitial = nil
+        adLoadTimestamp = nil
+        
         guard let diaryId = currentDiaryId else { return }
         pushDiaryDetail(diaryId: diaryId)
     }

--- a/HilingualPresentation/Sources/Presentation/Loading/LoadingViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Loading/LoadingViewController.swift
@@ -140,16 +140,25 @@ public final class LoadingViewController: BaseUIViewController<LoadingViewModel>
                 return
             }
             
+            guard let ad = ad else {
+                print("🚨 예외 상황: 에러는 없으나 광고 객체가 nil입니다.")
+                self.retryLoadingAdIfNeeded()
+                return
+            }
+            
             self.adLoadRetryCount = 0
             self.interstitial = ad
             self.interstitial?.fullScreenContentDelegate = self
             self.adLoadTimestamp = Date()
             print("✅ 광고 로드 완료")
             
-            if let pendingDiaryId = self.pendingDiaryId, let ad = ad {
+            if let pendingDiaryId = self.pendingDiaryId {
                 self.pendingDiaryId = nil
                 self.currentDiaryId = pendingDiaryId
-                ad.present(from: self)
+                
+                DispatchQueue.main.async {
+                    ad.present(from: self)
+                }
             }
         }
     }
@@ -189,7 +198,9 @@ public final class LoadingViewController: BaseUIViewController<LoadingViewModel>
                 
                 if let ad = self.interstitial, self.isAdValid() {
                     self.currentDiaryId = diaryId
-                    ad.present(from: self)
+                    DispatchQueue.main.async {
+                        ad.present(from: self)
+                    }
                 }
                 else if self.adLoadRetryCount < Self.maxAdRetryCount {
                     self.pendingDiaryId = diaryId

--- a/HilingualPresentation/Sources/Presentation/Loading/LoadingViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Loading/LoadingViewController.swift
@@ -13,6 +13,10 @@ public final class LoadingViewController: BaseUIViewController<LoadingViewModel>
     
     // MARK: - Properties
     
+    private var adLoadRetryCount = 0
+    private static let maxAdRetryCount = 3
+    private var pendingDiaryId: Int?
+    
     private let loadingView = LoadingView()
     private var interstitial: InterstitialAd?
     
@@ -126,25 +130,56 @@ public final class LoadingViewController: BaseUIViewController<LoadingViewModel>
             with: Bundle.main.infoDictionary?["AD_INTERSTITIAL_UNIT_ID"] as? String ?? "",
             request: Request()
         ) { [weak self] ad, error in
+            guard let self else { return }
             if let error {
                 print("Interstitial load failed: \(error)")
+                self.retryLoadingAdIfNeeded()
                 return
             }
-            self?.interstitial = ad
-            self?.interstitial?.fullScreenContentDelegate = self
+            self.adLoadRetryCount = 0
+            self.interstitial = ad
+            self.interstitial?.fullScreenContentDelegate = self
+            
+            if let pendingDiaryId = self.pendingDiaryId, let ad = ad {
+                self.pendingDiaryId = nil
+                self.currentDiaryId = pendingDiaryId
+                ad.present(from: self)
+            }
         }
     }
-    
+    private func retryLoadingAdIfNeeded() {
+        guard adLoadRetryCount < Self.maxAdRetryCount else {
+            print("Ad load failed after \(Self.maxAdRetryCount) retries")
+            if let pendingDiaryId = self.pendingDiaryId {
+                self.pendingDiaryId = nil
+                DispatchQueue.main.async {
+                    self.pushDiaryDetail(diaryId: pendingDiaryId)
+                }
+            }
+            return
+        }
+        
+        let delay = pow(2.0, Double(adLoadRetryCount))
+        adLoadRetryCount += 1
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            self?.loadInterstitialAd()
+        }
+    }
+
     private func goToNextView() {
         viewModel?.diaryIdPublisher
             .compactMap { $0 }
             .first()
             .sink { [weak self] (diaryId: Int) in
-                guard let self = self else { return }
-                self.currentDiaryId = diaryId
+                guard let self else { return }
                 if let ad = self.interstitial {
+                    self.currentDiaryId = diaryId
                     ad.present(from: self)
+                } else if self.adLoadRetryCount < Self.maxAdRetryCount {
+                    self.pendingDiaryId = diaryId
                 } else {
+                    self.currentDiaryId = diaryId
                     self.pushDiaryDetail(diaryId: diaryId)
                 }
             }
@@ -166,13 +201,14 @@ public final class LoadingViewController: BaseUIViewController<LoadingViewModel>
 
 extension LoadingViewController: FullScreenContentDelegate {
     public func adDidDismissFullScreenContent(_ ad: FullScreenPresentingAd) {
+        interstitial = nil
         guard let diaryId = currentDiaryId else { return }
         viewModel?.patchAdWatch(diaryId: diaryId)
         pushDiaryDetail(diaryId: diaryId)
     }
     
     public func ad(_ ad: FullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
-        print("Interstitial present failed: \(error)")
+        interstitial = nil
         guard let diaryId = currentDiaryId else { return }
         pushDiaryDetail(diaryId: diaryId)
     }


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #429 

---

## 📎 Work Description 
- **일기 완료 시점 광고 프리로드 적용**
기존에는 LoadingViewController 진입 후 viewDidLoad 시점에 광고를 단발성으로 로드하기 시작하여, 
네트워크 상황에 따라 광고 노출까지 지연이 발생하거나 빈 화면이 오래 머무는 문제가 발생할 수 있었습니다. 
➡️ 이를 일기 작성 완료 버튼을 누를 때, 일기 등록 API 호출과 광고 프리로드를 동시에 병렬로 시작하도록 타이밍을 변경했습니다.
 

- **광고 로드 실패 대응 및 재시도 로직 추가**
광고 로드에 1회만 실패해도 재시도 없이 바로 화면이 넘어가도록 구현했었습니다. 
➡️ 이를 최대 3회까지 대기 시간을 2배씩 늘려가며 요청하는 지수 백오프 재시도 구조를 도입했습니다.


- **Google AdMob 가이드라인 및 만료 정책 준수**
프리로드된 광고의 로드 시점을 기록하지 않아 Google 정책상 1시간이 지나 만료된 광고가 노출될 수 있는 무효 클릭 리스크가 있었습니다. 또한 광고가 닫힌 후 인스턴스 관리가 모호했는데요. 
➡️ adLoadTimestamp를 추가해 1시간 이내의 유효한 광고인지 검증하는 로직을 반영했고, 
광고가 정상적으로 닫히거나 노출에 실패했을 때 기존 인스턴스를 즉시 비워주도록 delegate 코드를 정비했습니다.

---

## 💬 To Reviewers  
한줄요약 : LoadingVC 이전에 미리 로드되게 수정 / 광고 로드 실패 시 최대 3회까지 도전 / Google AdMob 가이드라인 1시간 규칙 준수하는 방향으로 로직을 수정했다 ~