### PR TITLE
[fix] 2차 QA 수정 

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/Home/HomeModal.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Home/HomeModal.swift
@@ -77,6 +77,7 @@ final class HomeModal: UIView, UIGestureRecognizerDelegate {
     
     // MARK: - Properties
     
+    var onDismiss: (() -> Void)?
     private let buttonLabelStyle: ButtonLabelStyle
     private var buttonAction: (() -> Void)?
     private var buttonTextAction: (() -> Void)?
@@ -178,11 +179,17 @@ final class HomeModal: UIView, UIGestureRecognizerDelegate {
     }
     
     @objc public func dismissModal() {
+        dismissModalAfterAnimation(completion: nil)
+    }
+    
+    public func dismissModalAfterAnimation(completion: (() -> Void)?) {
         UIView.animate(withDuration: 0.2) {
             self.alpha = 0
         } completion: { _ in
             self.alpha = 1
             self.isHidden = true
+            self.onDismiss?()
+            completion?()
         }
     }
     

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -29,6 +29,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     private var pendingRecoveryDate: Date?
     private var recoveryTickets = 0
     private var didLoadFilledDates = false
+    private var dismissedRecoveryModalMonthInCurrentAppearance: String?
     private var recoveredDateKeys: Set<String> = []
     private let recoveredDateStorageKey = "home.recoveredDateKeys"
     private let dismissedRecoveryModalMonthStorageKey = "home.dismissedRecoveryModalMonth"
@@ -406,12 +407,15 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     private func canShowRecoveryModal(today: Date, selectedDate: Date) -> Bool {
         let calendar = Calendar.current
         let lastDay = calendar.range(of: .day, in: .month, for: today)?.count ?? 31
-        let alreadyDismissed = UserDefaults.standard.string(forKey: dismissedRecoveryModalMonthStorageKey) == monthKey(today)
+        let currentMonthKey = monthKey(today)
+        let alreadyDismissed = UserDefaults.standard.string(forKey: dismissedRecoveryModalMonthStorageKey) == currentMonthKey
+        let alreadyDismissedInCurrentAppearance = dismissedRecoveryModalMonthInCurrentAppearance == currentMonthKey
         
         return didLoadFilledDates
         && recoveryTickets > 0
         && calendar.isDate(selectedDate, equalTo: today, toGranularity: .month)
         && !alreadyDismissed
+        && !alreadyDismissedInCurrentAppearance
         && calendar.component(.day, from: today) >= lastDay - 7
     }
     
@@ -445,6 +449,9 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
             }
         }
         
+        homeModal.onDismiss = { [weak self] in
+            self?.dismissedRecoveryModalMonthInCurrentAppearance = self?.monthKey(Date())
+        }
         homeModal.isHidden = false
         homeModal.configure(
             title: "연속 기록이 끊겼나요?",

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -29,7 +29,8 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     private var pendingRecoveryDate: Date?
     private var recoveryTickets = 0
     private var didLoadFilledDates = false
-    private var dismissedRecoveryModalMonthInCurrentAppearance: String?
+    private var temporarilyDismissedRecoveryMonth: String?
+    private var isRecoveryWritingFlowActive = false
     private var recoveredDateKeys: Set<String> = []
     private let recoveredDateStorageKey = "home.recoveredDateKeys"
     private let dismissedRecoveryModalMonthStorageKey = "home.dismissedRecoveryModalMonth"
@@ -75,6 +76,14 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         if !showOnboardingBottomSheet() {
             showNextHomeModal()
         }
+        finishRecoveryWritingFlowIfNeeded()
+    }
+    
+    public override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        if isRecoveryWritingFlowActive { return }
+        temporarilyDismissedRecoveryMonth = nil
     }
     
     // MARK: - Bind
@@ -254,6 +263,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
             guard let selectedDate = self.homeView.calendarView.selectedDate else { return }
 
             self.pendingRecoveryDate = selectedDate
+            self.isRecoveryWritingFlowActive = true
             self.loadInterstitialAdAndPresent()
         }
     }
@@ -291,6 +301,15 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         if !showUpdateNoticeModalIfNeeded() {
             showRecoveryModalIfNeeded()
         }
+    }
+    
+    private func finishRecoveryWritingFlowIfNeeded() {
+        guard isRecoveryWritingFlowActive else { return }
+        guard pendingRecoveryDate == nil,
+              rewardedInterstitial == nil,
+              recoveryTransitionOverlay == nil else { return }
+        
+        isRecoveryWritingFlowActive = false
     }
     
     private func showUpdateNoticeModalIfNeeded() -> Bool {
@@ -407,13 +426,13 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         let lastDay = calendar.range(of: .day, in: .month, for: today)?.count ?? 31
         let currentMonthKey = monthKey(today)
         let alreadyDismissed = UserDefaults.standard.string(forKey: dismissedRecoveryModalMonthStorageKey) == currentMonthKey
-        let alreadyDismissedInCurrentAppearance = dismissedRecoveryModalMonthInCurrentAppearance == currentMonthKey
+        let temporarilyDismissed = temporarilyDismissedRecoveryMonth == currentMonthKey
         
         return didLoadFilledDates
         && recoveryTickets > 0
         && calendar.isDate(selectedDate, equalTo: today, toGranularity: .month)
         && !alreadyDismissed
-        && !alreadyDismissedInCurrentAppearance
+        && !temporarilyDismissed
         && calendar.component(.day, from: today) == lastDay - 7
     }
     
@@ -448,7 +467,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         }
         
         homeModal.onDismiss = { [weak self] in
-            self?.dismissedRecoveryModalMonthInCurrentAppearance = self?.monthKey(Date())
+            self?.temporarilyDismissedRecoveryMonth = self?.monthKey(Date())
         }
         homeModal.isHidden = false
         homeModal.configure(
@@ -953,6 +972,10 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         shouldLoadDraft: Bool = false,
         isRecoveryWriting: Bool = false
     ) {
+        if isRecoveryWriting {
+            isRecoveryWritingFlowActive = true
+        }
+        
         let diaryWritingVC = diContainer.makeDiaryWritingViewController(
             topicData: topicData,
             selectedDate: selectedDate ?? Date(),
@@ -1065,6 +1088,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         pendingRecoveryDate = nil
         rewardedInterstitial = nil
         didEarnRecoveryReward = false
+        isRecoveryWritingFlowActive = false
         hideRecoveryTransitionOverlay()
     }
 

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -377,21 +377,19 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         UserDefaults.standard.set(monthKey(Date()), forKey: dismissedRecoveryModalMonthStorageKey)
     }
     
-    @discardableResult
-    private func showRecoveryModalIfNeeded() -> Bool {
+    private func showRecoveryModalIfNeeded() {
         let today = Date()
         let selectedDate = homeView.calendarView.selectedDate ?? today
         
-        guard !isShowingOnboardingBottomSheet else { return false }
-        guard !UserDefaults.standard.bool(forKey: "showHomeOnboarding") else { return false }
-        guard canShowRecoveryModal(today: today, selectedDate: selectedDate) else { return false }
-        guard let recoveryDate = mostRecentRecoveryViewDateInCurrentMonth() else { return false }
+        guard !isShowingOnboardingBottomSheet else { return }
+        guard !UserDefaults.standard.bool(forKey: "showHomeOnboarding") else { return }
+        guard canShowRecoveryModal(today: today, selectedDate: selectedDate) else { return }
+        guard let recoveryDate = mostRecentRecoveryViewDateInCurrentMonth() else { return }
         
-        guard !isUpdateNoticeModalVisible else { return false }
-        guard !shouldShowUpdateNoticeModal() else { return false }
-        guard !isHomeModalVisible else { return false }
+        guard !isUpdateNoticeModalVisible else { return }
+        guard !shouldShowUpdateNoticeModal() else { return }
+        guard !isHomeModalVisible else { return }
         showRecoveryModal(for: recoveryDate)
-        return true
     }
     
     private var isHomeModalVisible: Bool {

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -414,7 +414,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         && calendar.isDate(selectedDate, equalTo: today, toGranularity: .month)
         && !alreadyDismissed
         && !alreadyDismissedInCurrentAppearance
-        && calendar.component(.day, from: today) >= lastDay - 7
+        && calendar.component(.day, from: today) == lastDay - 7
     }
     
     private func mostRecentRecoveryViewDateInCurrentMonth() -> Date? {

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -14,6 +14,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     // MARK: - Properties
     
     private var hasShownOnboardingBottomSheet = false
+    private var isShowingOnboardingBottomSheet = false
     private var onboardingBottomSheet: OnboardingBottomSheet?
     private var overlayView: UIControl?
     private let homeView = HomeView()
@@ -263,12 +264,15 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         guard !hasShownOnboardingBottomSheet else { return false }
         
         hasShownOnboardingBottomSheet = true
+        isShowingOnboardingBottomSheet = true
 
         let bottomSheet = OnboardingBottomSheet()
         onboardingBottomSheet = bottomSheet
         bottomSheet.onDismiss = { [weak self] in
-            self?.onboardingBottomSheet = nil
-            self?.showNextHomeModal()
+            guard let self else { return }
+            self.onboardingBottomSheet = nil
+            self.isShowingOnboardingBottomSheet = false
+            self.showNextHomeModal()
         }
 
         view.window?.addSubview(bottomSheet)
@@ -281,16 +285,22 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     }
     
     private func showNextHomeModal() {
+        guard !isHomeModalVisible else { return }
+        
         if !showUpdateNoticeModalIfNeeded() {
             showRecoveryModalIfNeeded()
         }
     }
     
     private func showUpdateNoticeModalIfNeeded() -> Bool {
-        guard let window = view.window,
-              !UserDefaults.standard.bool(forKey: didShowUpdateNoticeModalStorageKey) else { return false }
+        guard !isShowingOnboardingBottomSheet,
+              let window = view.window,
+              shouldShowUpdateNoticeModal() else { return false }
         
-        UserDefaults.standard.set(true, forKey: didShowUpdateNoticeModalStorageKey)
+        markUpdateNoticeModalAsShown()
+        updateNoticeModal.onDismiss = { [weak self] in
+            self?.showRecoveryModalIfNeeded()
+        }
         window.addSubview(updateNoticeModal)
         updateNoticeModal.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -305,11 +315,18 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
             buttonText: nil,
             buttonAction: { [weak self] in
                 self?.updateNoticeModal.dismissModal()
-                self?.showRecoveryModalIfNeeded()
             }
         )
         updateNoticeModal.showAnimation()
         return true
+    }
+    
+    private func shouldShowUpdateNoticeModal() -> Bool {
+        !UserDefaults.standard.bool(forKey: didShowUpdateNoticeModalStorageKey)
+    }
+    
+    private func markUpdateNoticeModalAsShown() {
+        UserDefaults.standard.set(true, forKey: didShowUpdateNoticeModalStorageKey)
     }
     
     private func dateKey(_ date: Date) -> String {
@@ -359,21 +376,31 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         UserDefaults.standard.set(monthKey(Date()), forKey: dismissedRecoveryModalMonthStorageKey)
     }
     
-    private func showRecoveryModalIfNeeded() {
+    @discardableResult
+    private func showRecoveryModalIfNeeded() -> Bool {
         let today = Date()
         let selectedDate = homeView.calendarView.selectedDate ?? today
         
-        guard !isHomeModalVisible else { return }
-        guard canShowRecoveryModal(today: today, selectedDate: selectedDate) else { return }
-        guard let recoveryDate = mostRecentRecoveryViewDateInCurrentMonth() else { return }
+        guard !isShowingOnboardingBottomSheet else { return false }
+        guard !UserDefaults.standard.bool(forKey: "showHomeOnboarding") else { return false }
+        guard canShowRecoveryModal(today: today, selectedDate: selectedDate) else { return false }
+        guard let recoveryDate = mostRecentRecoveryViewDateInCurrentMonth() else { return false }
         
+        guard !isUpdateNoticeModalVisible else { return false }
+        guard !shouldShowUpdateNoticeModal() else { return false }
+        guard !isHomeModalVisible else { return false }
         showRecoveryModal(for: recoveryDate)
+        return true
     }
     
     private var isHomeModalVisible: Bool {
-        onboardingBottomSheet?.superview != nil
+        isShowingOnboardingBottomSheet
         || (homeModal.superview != nil && !homeModal.isHidden)
-        || (updateNoticeModal.superview != nil && !updateNoticeModal.isHidden)
+        || isUpdateNoticeModalVisible
+    }
+    
+    private var isUpdateNoticeModalVisible: Bool {
+        updateNoticeModal.superview != nil && !updateNoticeModal.isHidden
     }
     
     private func canShowRecoveryModal(today: Date, selectedDate: Date) -> Bool {

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -102,12 +102,11 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
             guard let self else { return }
             
             let calendar = Calendar.current
-            let existingSelected = self.homeView.calendarView.selectedDate
+            let today = Date()
             let selectedDate: Date
-            if let existingSelected,
-               calendar.component(.year, from: existingSelected) == year,
-               calendar.component(.month, from: existingSelected) == month {
-                selectedDate = existingSelected
+            if calendar.component(.year, from: today) == year,
+               calendar.component(.month, from: today) == month {
+                selectedDate = today
             } else {
                 selectedDate = calendar.date(from: DateComponents(year: year, month: month, day: 1))!
             }


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #448

---

## 📎 Work Description 
- 온보딩 바텀 시트 노출 중 업데이트 모달이 동시에 표시되어 화면이 복잡하게 보이는 문제 수정
  → 온보딩 바텀 시트 종료 후 업데이트 모달이 노출되도록 순서 조정
  (온보딩 바텀 시트의 ‘시작하기’ 버튼, ‘X’ 버튼, 또는 배경 영역 터치 시)

- 온보딩 바텀 시트 배경 영역 터치 후 재접속 시 온보딩이 다시 노출되는 문제 수정
  → 월 변경 시에는 재노출되지 않도록 하고, 앱 재진입 시에만 노출되도록 로직 수정

---

## 📷 Screenshots  

| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| A 기능 | <img src="" width="250"> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |

---

## 💬 To Reviewers  
- 가능하시면 해당 브랜치로 기록 되살리기 테스트 시도해주세요! 오류가 난다는데 저한테는 안 떠서 ... ㅠ.ㅠ
- 많은것을 유저디폴트에 저장하고 있느라 뚱뚱 홈VC 됐는데 이게 맞을까요 ..... 휴 