### PR TITLE
[feat] Amplitude 토글 클릭 이벤트 추가

### DIFF
--- a/Hilingual/App/AppDIContainer.swift
+++ b/Hilingual/App/AppDIContainer.swift
@@ -11,6 +11,7 @@ import HilingualDomain
 import HilingualData
 import HilingualNetwork
 import HilingualPresentation
+import HilingualCore
 
 // MARK: - DIContainer Entry Point
 
@@ -55,15 +56,26 @@ final class AppDIContainer: ViewControllerFactory {
         )
     }
     
-    public func makeFeedbackViewController(diaryId: Int) -> FeedbackViewController {
-//        return FeedbackViewController(viewModel: makeFeedbackViewModel(diaryId: diaryId), diContainer: self)
+    public func makeFeedbackViewController(diaryId: Int, page: String? = nil) -> FeedbackViewController {
+        let pageEnum: AnalyticsEvent.Page = {
+            switch page {
+            case "posted_diary": return .postedDiary
+            default: return .feedback
+            }
+        }()
+        
         let viewModel = FeedbackViewModel(
-                diaryId: diaryId,
-                diaryDetailUseCase: makeDiaryDetailUseCase(),
-                feedbackUseCase: makeFeedbackUseCase(),
-                homeUseCase: makeHomeUseCase()
-            )
-            return FeedbackViewController(viewModel: viewModel, diContainer:  self)
+            diaryId: diaryId,
+            diaryDetailUseCase: makeDiaryDetailUseCase(),
+            feedbackUseCase: makeFeedbackUseCase(),
+            homeUseCase: makeHomeUseCase()
+        )
+        return FeedbackViewController(
+            viewModel: viewModel,
+            diContainer: self,
+            diaryId: diaryId,
+            page: pageEnum
+        )
     }
     
     public func makeRecommendedExpressionViewController(diaryId: Int) -> RecommendedExpressionViewController {

--- a/Hilingual/App/AppDIContainer.swift
+++ b/Hilingual/App/AppDIContainer.swift
@@ -11,7 +11,6 @@ import HilingualDomain
 import HilingualData
 import HilingualNetwork
 import HilingualPresentation
-import HilingualCore
 
 // MARK: - DIContainer Entry Point
 

--- a/Hilingual/App/AppDIContainer.swift
+++ b/Hilingual/App/AppDIContainer.swift
@@ -56,14 +56,7 @@ final class AppDIContainer: ViewControllerFactory {
         )
     }
     
-    public func makeFeedbackViewController(diaryId: Int, page: String? = nil) -> FeedbackViewController {
-        let pageEnum: AnalyticsEvent.Page = {
-            switch page {
-            case "posted_diary": return .postedDiary
-            default: return .feedback
-            }
-        }()
-        
+    public func makeFeedbackViewController(diaryId: Int) -> FeedbackViewController {
         let viewModel = FeedbackViewModel(
             diaryId: diaryId,
             diaryDetailUseCase: makeDiaryDetailUseCase(),
@@ -73,8 +66,7 @@ final class AppDIContainer: ViewControllerFactory {
         return FeedbackViewController(
             viewModel: viewModel,
             diContainer: self,
-            diaryId: diaryId,
-            page: pageEnum
+            diaryId: diaryId
         )
     }
     

--- a/HilingualCore/Sources/HilingualCore/Analytics/AnalyticsEvent.swift
+++ b/HilingualCore/Sources/HilingualCore/Analytics/AnalyticsEvent.swift
@@ -8,7 +8,7 @@ import Foundation
 public enum AnalyticsEvent {
     case pageviewFeed(entryId: String)
     case pageviewPostedDiary(entryId: String)
-    case pageviewFeedback
+    case pageviewFeedback(page: Page)
     case pageviewDiaryWriting(
         entryId: String,
         backSource: BackSource,
@@ -34,7 +34,7 @@ public enum AnalyticsEvent {
     )
     case clickBackDiary(entryId: String, backSource: BackSource)
     case clickTextfield(entryId: String, inputType: TextInputType, timeToFirstInput: Int)
-    case clickFeedbackToggle(page: String, toggleState: Bool)
+    case clickFeedbackToggle(page: Page, toggleClickCount: Int, toggleState: Bool)
     case bookmarkAction(entryId: String, entrySource: EntrySource, action: BookmarkAction)
     case toastAction(action: ToastAction, toastId: ToastId, entryId: String)
     case clickBackFeedback(entryId: String, backSource: BackSource)
@@ -57,7 +57,7 @@ extension AnalyticsEvent {
              .pageviewDiaryWriting:
             return "pageview"
         case .viewProfileUser:
-            return "viewe_profile_user"
+            return "view_profile_user"
         default:
             return snakeCaseName
         }
@@ -83,9 +83,9 @@ extension AnalyticsEvent {
                 "entry_id": entryId,
                 "tab_name": TabName.postedDiary.analyticsPropertyName
             ]
-        case .pageviewFeedback:
+        case let .pageviewFeedback(page):
             return [
-                "page": Page.feedback.analyticsPropertyName
+                "page": page.analyticsPropertyName
             ]
         case let .pageviewDiaryWriting(entryId, backSource, selectedDate, recommendedTopic):
             return [
@@ -144,9 +144,10 @@ extension AnalyticsEvent {
                 "text_input_type": inputType.analyticsPropertyName,
                 "time_to_first_input": timeToFirstInput
             ]
-        case let .clickFeedbackToggle(page, toggleState):
+        case let .clickFeedbackToggle(page, toggleClickCount, toggleState):
             return [
-                "page": page,
+                "page": page.analyticsPropertyName,
+                "toggle_click_count": toggleClickCount,
                 "toggle_state": toggleState
             ]
         case let .bookmarkAction(entryId, entrySource, action):
@@ -250,15 +251,17 @@ extension AnalyticsEvent {
         case userProfile
         case notification
         case feedback
+        case postedDiary
         case vocabulary
         case custom(String)
 
-        var analyticsPropertyName: String {
+        public var analyticsPropertyName: String {
             switch self {
             case .feed: return "feed"
             case .userProfile: return "user_profile"
             case .notification: return "notification"
             case .feedback: return "feedback"
+            case .postedDiary: return "posted_diary"
             case .vocabulary: return "vocabulary"
             case .custom(let value): return value
             }

--- a/HilingualCore/Sources/HilingualCore/Analytics/AnalyticsEvent.swift
+++ b/HilingualCore/Sources/HilingualCore/Analytics/AnalyticsEvent.swift
@@ -34,7 +34,7 @@ public enum AnalyticsEvent {
     )
     case clickBackDiary(entryId: String, backSource: BackSource)
     case clickTextfield(entryId: String, inputType: TextInputType, timeToFirstInput: Int)
-    case clickFeedbackToggle(clickCount: Int, isEnabled: Bool)
+    case clickFeedbackToggle(page: String, toggleState: Bool)
     case bookmarkAction(entryId: String, entrySource: EntrySource, action: BookmarkAction)
     case toastAction(action: ToastAction, toastId: ToastId, entryId: String)
     case clickBackFeedback(entryId: String, backSource: BackSource)
@@ -144,10 +144,10 @@ extension AnalyticsEvent {
                 "text_input_type": inputType.analyticsPropertyName,
                 "time_to_first_input": timeToFirstInput
             ]
-        case let .clickFeedbackToggle(clickCount, isEnabled):
+        case let .clickFeedbackToggle(page, toggleState):
             return [
-                "toggle_click_count": clickCount,
-                "toggle_state": isEnabled
+                "page": page,
+                "toggle_state": toggleState
             ]
         case let .bookmarkAction(entryId, entrySource, action):
             return [

--- a/HilingualCore/Sources/HilingualCore/Analytics/AnalyticsEvent.swift
+++ b/HilingualCore/Sources/HilingualCore/Analytics/AnalyticsEvent.swift
@@ -255,7 +255,7 @@ extension AnalyticsEvent {
         case vocabulary
         case custom(String)
 
-        public var analyticsPropertyName: String {
+        var analyticsPropertyName: String {
             switch self {
             case .feed: return "feed"
             case .userProfile: return "user_profile"

--- a/HilingualPresentation/Sources/Presentation/Common/Factory/ViewControllerFactory.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Factory/ViewControllerFactory.swift
@@ -19,7 +19,7 @@ public protocol ViewControllerFactory {
     func makeLoadingViewController() -> LoadingViewController
     func makeWordBookViewController() -> WordBookViewController
     func makeDiaryDetailViewController(diaryId: Int) -> DiaryDetailViewController
-    func makeFeedbackViewController(diaryId: Int) -> FeedbackViewController
+    func makeFeedbackViewController(diaryId: Int, page: String?) -> FeedbackViewController
     func makeRecommendedExpressionViewController(diaryId: Int) -> RecommendedExpressionViewController
     func makeDiaryWritingViewController(
         topicData: (String, String)?,

--- a/HilingualPresentation/Sources/Presentation/Common/Factory/ViewControllerFactory.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Factory/ViewControllerFactory.swift
@@ -19,7 +19,7 @@ public protocol ViewControllerFactory {
     func makeLoadingViewController() -> LoadingViewController
     func makeWordBookViewController() -> WordBookViewController
     func makeDiaryDetailViewController(diaryId: Int) -> DiaryDetailViewController
-    func makeFeedbackViewController(diaryId: Int, page: String?) -> FeedbackViewController
+    func makeFeedbackViewController(diaryId: Int) -> FeedbackViewController
     func makeRecommendedExpressionViewController(diaryId: Int) -> RecommendedExpressionViewController
     func makeDiaryWritingViewController(
         topicData: (String, String)?,

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift
@@ -75,10 +75,8 @@ public final class DiaryDetailViewController: BaseUIViewController<DiaryDetailVi
         
         super.init(viewModel: viewModel, diContainer: diContainer)
         
-        self.feedbackViewController = diContainer.makeFeedbackViewController(
-            diaryId: diaryId,
-            page: self.feedbackPage.analyticsPropertyName
-        )
+        self.feedbackViewController = diContainer.makeFeedbackViewController(diaryId: diaryId)
+        self.feedbackViewController.page = self.feedbackPage
     }
 
     required init?(coder: NSCoder) {

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift
@@ -53,7 +53,6 @@ public final class DiaryDetailViewController: BaseUIViewController<DiaryDetailVi
     private var entryId: String = ""
     private var entrySource: String = "unknown"
     private var backSource: String = "ui_button"
-    private var toggleClickCount: Int = 0
 
     // MARK: - Init
 
@@ -107,19 +106,7 @@ public final class DiaryDetailViewController: BaseUIViewController<DiaryDetailVi
             self?.isPublished = isPublished
             self?.updateButtonTitle()
         }
-
-        feedbackViewController.onToggleChanged = { [weak self] isEnabled in
-            guard let self = self else { return }
-            self.toggleClickCount += 1
-
-            AmplitudeManager.shared.send(
-                .clickFeedbackToggle(
-                    clickCount: self.toggleClickCount,
-                    isEnabled: isEnabled
-                )
-            )
-        }
-
+        
         recommendedExpressionViewController.onBookmarkToggle = { [weak self] phraseId, isBookmarked in
             guard let self = self else { return }
 

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/DiaryDetailViewController.swift
@@ -17,6 +17,12 @@ public final class DiaryDetailViewController: BaseUIViewController<DiaryDetailVi
 
     let diaryId: Int
     var date: String = ""
+    private var toggleClickCount: Int = 0
+    public var feedbackPage: AnalyticsEvent.Page = .feedback {
+        didSet {
+            feedbackViewController?.page = feedbackPage
+        }
+    }
     private var isPublished: Bool = true
     private let deleteTappedSubject = PassthroughSubject<Void, Never>()
     private let publishTappedSubject = PassthroughSubject<Void, Never>()
@@ -42,7 +48,8 @@ public final class DiaryDetailViewController: BaseUIViewController<DiaryDetailVi
         return button
     }()
 
-    private lazy var feedbackViewController = diContainer.makeFeedbackViewController(diaryId: diaryId)
+    private var feedbackViewController: FeedbackViewController!
+    
     private lazy var recommendedExpressionViewController = diContainer.makeRecommendedExpressionViewController(diaryId: diaryId)
 
     private var segmentedControl: SegmentedControl!
@@ -65,7 +72,13 @@ public final class DiaryDetailViewController: BaseUIViewController<DiaryDetailVi
         self.diaryId = diaryId
         self.entryId = String(diaryId)
         self.entrySource = entrySource
+        
         super.init(viewModel: viewModel, diContainer: diContainer)
+        
+        self.feedbackViewController = diContainer.makeFeedbackViewController(
+            diaryId: diaryId,
+            page: self.feedbackPage.analyticsPropertyName
+        )
     }
 
     required init?(coder: NSCoder) {
@@ -79,8 +92,6 @@ public final class DiaryDetailViewController: BaseUIViewController<DiaryDetailVi
         
         feedbackViewController.showsAdBanner = !showsActionButton
         recommendedExpressionViewController.showsAdBanner = !showsActionButton
-
-        AmplitudeManager.shared.send(.pageviewFeedback)
 
         hideKeyboardWhenTappedAround()
         updateButtonTitle()
@@ -105,6 +116,19 @@ public final class DiaryDetailViewController: BaseUIViewController<DiaryDetailVi
         feedbackViewController.publishedInfoLoaded = { [weak self] isPublished in
             self?.isPublished = isPublished
             self?.updateButtonTitle()
+        }
+        
+        feedbackViewController.onToggleChanged = { [weak self] isEnabled in
+            guard let self else { return }
+            self.toggleClickCount += 1
+            
+            AmplitudeManager.shared.send(
+                .clickFeedbackToggle(
+                    page: self.feedbackPage,
+                    toggleClickCount: self.toggleClickCount,
+                    toggleState: isEnabled
+                )
+            )
         }
         
         recommendedExpressionViewController.onBookmarkToggle = { [weak self] phraseId, isBookmarked in

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackViewController.swift
@@ -36,18 +36,22 @@ public final class FeedbackViewController: BaseUIViewController<FeedbackViewMode
     var onDateLoaded: ((String) -> Void)?
     var publishedInfoLoaded: ((Bool) -> Void)?
     var onToggleChanged: ((Bool) -> Void)?
-
-    private var date: String = ""
-
-    private let feedbackView = FeedbackView()
-    private let dialog = Dialog()
-
     private let viewDidLoadSubject = PassthroughSubject<Void, Never>()
+    private var date: String = ""
+    
+    // Amplitude Tracking Properties
 
-    // MARK: - Ad
+    private var toggleClickCount: Int = 0
+    public var page: AnalyticsEvent.Page
 
+    // Ad
     public var showsAdBanner: Bool = false
     private var bannerView: BannerView?
+    
+    // MARK: - UI Components
+    
+    private let feedbackView = FeedbackView()
+    private let dialog = Dialog()
 
     private lazy var adPlaceholderImageView: UIImageView = {
         let imageView = UIImageView(image: UIImage(resource: .imgLoadingFeedIos))
@@ -57,16 +61,39 @@ public final class FeedbackViewController: BaseUIViewController<FeedbackViewMode
     }()
 
     // MARK: - LifeCycle
+    
+    public init(viewModel: FeedbackViewModel,
+                diContainer: any ViewControllerFactory,
+                diaryId: Int,
+                page: AnalyticsEvent.Page = .feedback) {
+        self.page = page
+        super.init(viewModel: viewModel, diContainer: diContainer)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     public override func viewDidLoad() {
         super.viewDidLoad()
         viewDidLoadSubject.send(())
+        AmplitudeManager.shared.send(.pageviewFeedback(page: self.page))
 
         feedbackView.onToggleChanged = { [weak self] isEnabled in
-            AmplitudeManager.shared.send(
-                .clickFeedbackToggle(page: "feedback", toggleState: isEnabled)
-            )
-            self?.onToggleChanged?(isEnabled)
+            guard let self = self else { return }
+
+            if let customToggleAction = self.onToggleChanged {
+                customToggleAction(isEnabled)
+            } else {
+                self.toggleClickCount += 1
+                AmplitudeManager.shared.send(
+                    .clickFeedbackToggle(
+                        page: self.page,
+                        toggleClickCount: self.toggleClickCount,
+                        toggleState: isEnabled
+                    )
+                )
+            }
         }
         
         feedbackView.onDiaryPronunciationTapped = { isFirstPlay in

--- a/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/DiaryDetail/FeedbackViewController.swift
@@ -63,8 +63,12 @@ public final class FeedbackViewController: BaseUIViewController<FeedbackViewMode
         viewDidLoadSubject.send(())
 
         feedbackView.onToggleChanged = { [weak self] isEnabled in
+            AmplitudeManager.shared.send(
+                .clickFeedbackToggle(page: "feedback", toggleState: isEnabled)
+            )
             self?.onToggleChanged?(isEnabled)
         }
+        
         feedbackView.onDiaryPronunciationTapped = { isFirstPlay in
             AmplitudeManager.shared.send(.clickDiaryPronunciationBtn(isFirstPlay: isFirstPlay))
         }

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -432,7 +432,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         && calendar.isDate(selectedDate, equalTo: today, toGranularity: .month)
         && !alreadyDismissed
         && !temporarilyDismissed
-        && calendar.component(.day, from: today) == lastDay - 7
+        && calendar.component(.day, from: today) >= lastDay - 7
     }
     
     private func mostRecentRecoveryViewDateInCurrentMonth() -> Date? {

--- a/HilingualPresentation/Sources/Presentation/SharedDiary/SharedDiaryViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/SharedDiary/SharedDiaryViewController.swift
@@ -34,6 +34,7 @@ public final class SharedDiaryViewController: BaseUIViewController<SharedDiaryVi
     private lazy var diaryDetailViewController: DiaryDetailViewController = {
         let vc = diContainer.makeDiaryDetailViewController(diaryId: diaryId)
         vc.showsActionButton = false
+        vc.feedbackPage = .postedDiary
         return vc
     }()
     private let bottomSafeAreaBackgroundView = UIView()


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #447 

---

## 📎 Work Description 
[Event > 토글 버튼 클릭](https://app.notion.com/p/hilingual/278829677ebf81929d0ecef3a7952b7e?v=278829677ebf81cfb455000c9ab51613&source=copy_link)
- 위 노션 링크를 통해 작업에 필요했던 attribute를 확인할 수 있습니다.
- 기존에 AnalyticsEvent에 토글 클릭 이벤트의 파라미터를 변경하였습니다.

---

## 📷 Screenshots  
다음과 같이 DiaryDetailVC, FeedbackVC 모두 Amplitude 콘솔에서 정상적으로 이벤트 로그가 출력되는 것을 확인했습니다.
각각 처음 진입 후 토글을 3번 눌러 테스트 해보았습니다.
<br>

**1️⃣ [일기 작성 직후 피드백 화면]** FeedbackVC → `posted_diary`
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/e59f59cd-a142-4c0d-84f8-a1cf80b31971" />
<br>

**2️⃣ [피드 탭을 통해 다른 사람의 게시글을 눌러서 진입]** DiaryDetailVC → `feedback`
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/ae814038-5c59-4ebc-adea-30ad52061ae8" />

---

## 💬 To Reviewers  
- FeedbackVC이 feedback이 아니라 DiaryDetailVC이 feedback으로 page가 찍혀야하는 것이라서, 몹시 헷갈렸습니다... 네이밍 자체가 모호한 것 같아서 추후 리팩토링 하면 좋을 것 같습니다 ... 😮‍💨
- AnalyticsEvent 작업을 이번에 처음 인계받고 해보는 거라 맞는 방식으로 구현했는지, 더블체크 부탁드립니다 🙇🏻‍♀️
<br>

- 추가로, [0624_이벤트 네이밍 규칙] 사항 다들 한 번씩 확인해주세요 !!
<img width="373" height="374" alt="image" src="https://github.com/user-attachments/assets/50fbf379-5783-490d-9362-2303b6bfe464" />