### PR TITLE
[add] 엠플리튜드 유저id 세팅 + 파이어베이스 크래시 에널리틱스 추가 

### DIFF
--- a/Hilingual.xcodeproj/project.pbxproj
+++ b/Hilingual.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		E5C79B352E15282100E461C3 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C79B2D2E15282100E461C3 /* SceneDelegate.swift */; };
 		E5C84AC92E1538C700CBD669 /* AppDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C84AC82E1538C700CBD669 /* AppDIContainer.swift */; };
 		E5CBCFB42EC4B3E100475E81 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = E5CBCFB32EC4B3E100475E81 /* FirebaseCore */; };
+		E5CBCFC42EC4B3E100475E81 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = E5CBCFC32EC4B3E100475E81 /* FirebaseAnalytics */; };
+		E5CBCFC12EC4B3E100475E81 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = E5CBCFC02EC4B3E100475E81 /* FirebaseCrashlytics */; };
 		E5CBCFB62EC4B3E100475E81 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = E5CBCFB52EC4B3E100475E81 /* FirebaseRemoteConfig */; };
 		E5D5D0A92E171AC300DABE8D /* HilingualData in Frameworks */ = {isa = PBXBuildFile; productRef = E5D5D0A82E171AC300DABE8D /* HilingualData */; };
 		E5D5D0AC2E17289000DABE8D /* HilingualPresentation in Frameworks */ = {isa = PBXBuildFile; productRef = E5D5D0AB2E17289000DABE8D /* HilingualPresentation */; };
@@ -68,6 +70,8 @@
 			files = (
 				E5D5D0A92E171AC300DABE8D /* HilingualData in Frameworks */,
 				E5CBCFB42EC4B3E100475E81 /* FirebaseCore in Frameworks */,
+				E5CBCFC42EC4B3E100475E81 /* FirebaseAnalytics in Frameworks */,
+				E5CBCFC12EC4B3E100475E81 /* FirebaseCrashlytics in Frameworks */,
 				E5C2F3992E171575003DF6C4 /* HilingualDomain in Frameworks */,
 				1988F8F82B0F4E84A7827BF3 /* HilingualCore in Frameworks */,
 				3A1464192F59BD11001D047C /* GoogleMobileAds in Frameworks */,
@@ -158,6 +162,7 @@
 				E5C79B0C2E15281900E461C3 /* Resources */,
 				E5F1A0012FCB000100000001 /* Configure Firebase */,
 				E5151C022E15DEA700497996 /* Embed Frameworks */,
+				E5CBCFC22EC4B3E100475E81 /* Upload Crashlytics dSYM */,
 			);
 			buildRules = (
 			);
@@ -171,6 +176,8 @@
 				E5D5D0A82E171AC300DABE8D /* HilingualData */,
 				E5D5D0AB2E17289000DABE8D /* HilingualPresentation */,
 				E5CBCFB32EC4B3E100475E81 /* FirebaseCore */,
+				E5CBCFC32EC4B3E100475E81 /* FirebaseAnalytics */,
+				E5CBCFC02EC4B3E100475E81 /* FirebaseCrashlytics */,
 				E5CBCFB52EC4B3E100475E81 /* FirebaseRemoteConfig */,
 				3A1464182F59BD11001D047C /* GoogleMobileAds */,
 			);
@@ -252,6 +259,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\ncase \"${CONFIGURATION}\" in\n  Debug) FIREBASE_PLIST=\"${SRCROOT}/Hilingual/GoogleService-Info-Debug.plist\" ;;\n  Release) FIREBASE_PLIST=\"${SRCROOT}/Hilingual/GoogleService-Info-Release.plist\" ;;\n  *) echo \"error: Unsupported configuration ${CONFIGURATION}\" >&2; exit 1 ;;\nesac\n\nDESTINATION=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleService-Info.plist\"\nmkdir -p \"$(dirname \"${DESTINATION}\")\"\ncp \"${FIREBASE_PLIST}\" \"${DESTINATION}\"\n\necho \"Configured Firebase for ${CONFIGURATION}: ${FIREBASE_PLIST}\"\n";
+		};
+		E5CBCFC22EC4B3E100475E81 /* Upload Crashlytics dSYM */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			name = "Upload Crashlytics dSYM";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -396,10 +423,10 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -462,7 +489,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -566,6 +593,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E5A100022FCA000100000001 /* XCLocalSwiftPackageReference "HilingualDomain" */;
 			productName = HilingualDomain;
+		};
+		E5CBCFC02EC4B3E100475E81 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E5CBCFB22EC4B3E100475E81 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
+		E5CBCFC32EC4B3E100475E81 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E5CBCFB22EC4B3E100475E81 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
 		};
 		E5CBCFB32EC4B3E100475E81 /* FirebaseCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Hilingual.xcodeproj/project.pbxproj
+++ b/Hilingual.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		E5C84AC92E1538C700CBD669 /* AppDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C84AC82E1538C700CBD669 /* AppDIContainer.swift */; };
 		E5CBCFB42EC4B3E100475E81 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = E5CBCFB32EC4B3E100475E81 /* FirebaseCore */; };
 		E5CBCFB62EC4B3E100475E81 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = E5CBCFB52EC4B3E100475E81 /* FirebaseRemoteConfig */; };
-		E5CBCFB82EC4B4C900475E81 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E5CBCFB72EC4B4C900475E81 /* GoogleService-Info.plist */; };
 		E5D5D0A92E171AC300DABE8D /* HilingualData in Frameworks */ = {isa = PBXBuildFile; productRef = E5D5D0A82E171AC300DABE8D /* HilingualData */; };
 		E5D5D0AC2E17289000DABE8D /* HilingualPresentation in Frameworks */ = {isa = PBXBuildFile; productRef = E5D5D0AB2E17289000DABE8D /* HilingualPresentation */; };
 /* End PBXBuildFile section */
@@ -56,7 +55,8 @@
 		E5C79B292E15282100E461C3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E5C79B2D2E15282100E461C3 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E5C84AC82E1538C700CBD669 /* AppDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainer.swift; sourceTree = "<group>"; };
-		E5CBCFB72EC4B4C900475E81 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		E5CBCFB72EC4B4C900475E81 /* GoogleService-Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Debug.plist"; sourceTree = "<group>"; };
+		E5CBCFB82EC4B4C900475E81 /* GoogleService-Info-Release.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Release.plist"; sourceTree = "<group>"; };
 		E5D5D0A72E171AA900DABE8D /* HilingualData */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = HilingualData; sourceTree = "<group>"; };
 		E5D5D0AA2E1727BB00DABE8D /* HilingualPresentation */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = HilingualPresentation; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -128,7 +128,8 @@
 				E5C79B3B2E152AC800E461C3 /* App */,
 				E51DB2002E1CF7AD000C2BEA /* Hilingual.entitlements */,
 				E5C79B282E15282100E461C3 /* Info.plist */,
-				E5CBCFB72EC4B4C900475E81 /* GoogleService-Info.plist */,
+				E5CBCFB72EC4B4C900475E81 /* GoogleService-Info-Debug.plist */,
+				E5CBCFB82EC4B4C900475E81 /* GoogleService-Info-Release.plist */,
 			);
 			path = Hilingual;
 			sourceTree = "<group>";
@@ -155,6 +156,7 @@
 				E5C79B0A2E15281900E461C3 /* Sources */,
 				E5C79B0B2E15281900E461C3 /* Frameworks */,
 				E5C79B0C2E15281900E461C3 /* Resources */,
+				E5F1A0012FCB000100000001 /* Configure Firebase */,
 				E5151C022E15DEA700497996 /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -225,7 +227,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				E51B4C542E28DC11000B16D0 /* AppIcon.xcassets in Resources */,
-				E5CBCFB82EC4B4C900475E81 /* GoogleService-Info.plist in Resources */,
 				E5C79B322E15282100E461C3 /* LaunchScreen.storyboard in Resources */,
 				3A79AE882F953813000AC0AC /* Debug.xcconfig in Resources */,
 				3A79AE862F953801000AC0AC /* Release.xcconfig in Resources */,
@@ -233,6 +234,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		E5F1A0012FCB000100000001 /* Configure Firebase */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Hilingual/GoogleService-Info-Debug.plist",
+				"$(SRCROOT)/Hilingual/GoogleService-Info-Release.plist",
+			);
+			name = "Configure Firebase";
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\n\ncase \"${CONFIGURATION}\" in\n  Debug) FIREBASE_PLIST=\"${SRCROOT}/Hilingual/GoogleService-Info-Debug.plist\" ;;\n  Release) FIREBASE_PLIST=\"${SRCROOT}/Hilingual/GoogleService-Info-Release.plist\" ;;\n  *) echo \"error: Unsupported configuration ${CONFIGURATION}\" >&2; exit 1 ;;\nesac\n\nDESTINATION=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleService-Info.plist\"\nmkdir -p \"$(dirname \"${DESTINATION}\")\"\ncp \"${FIREBASE_PLIST}\" \"${DESTINATION}\"\n\necho \"Configured Firebase for ${CONFIGURATION}: ${FIREBASE_PLIST}\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		E5C79B0A2E15281900E461C3 /* Sources */ = {

--- a/Hilingual/App/AppDelegate.swift
+++ b/Hilingual/App/AppDelegate.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 import FirebaseCore
+import FirebaseCrashlytics
+import HilingualCore
 import HilingualData
 
 @main
@@ -15,6 +17,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         FirebaseApp.configure()
+        // 비치명(non-fatal) API 에러 리포팅은 RELEASE 빌드만. (한 프로젝트·프로젝트 단위 Slack이라 개발 중 에러가 Slack에 도배되는 것 방지 — Android ReleaseTree와 동일)
+        // 크래시는 빌드 무관하게 Crashlytics가 자동 수집한다.
+        #if !DEBUG
+        CrashReporter.reporter = FirebaseCrashReporter()
+        #endif
         UIFont.registerPretendardFonts()
 
 //        for key in UserDefaults.standard.dictionaryRepresentation().keys {
@@ -41,4 +48,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 
+}
+
+// MARK: - CrashReporting (Crashlytics 구현체)
+
+final class FirebaseCrashReporter: CrashReporting {
+
+    func record(_ error: Error, userInfo: [String: String]) {
+        let crashlytics = Crashlytics.crashlytics()
+        for (key, value) in userInfo {
+            crashlytics.setCustomValue(value, forKey: key)
+        }
+        crashlytics.record(error: error)
+    }
+
+    func log(_ message: String) {
+        Crashlytics.crashlytics().log(message)
+    }
 }

--- a/Hilingual/GoogleService-Info-Debug.plist
+++ b/Hilingual/GoogleService-Info-Debug.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyAumxzjHdUou4ePTIw9KxStEJbxX2FoYc4</string>
+	<key>GCM_SENDER_ID</key>
+	<string>414802359007</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.Hilingual.dev</string>
+	<key>PROJECT_ID</key>
+	<string>hi-lingual-de607</string>
+	<key>STORAGE_BUCKET</key>
+	<string>hi-lingual-de607.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false/>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false/>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true/>
+	<key>IS_GCM_ENABLED</key>
+	<true/>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true/>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:414802359007:ios:9bc0861821aad4d570af6a</string>
+</dict>
+</plist>

--- a/Hilingual/GoogleService-Info-Release.plist
+++ b/Hilingual/GoogleService-Info-Release.plist
@@ -15,15 +15,15 @@
 	<key>STORAGE_BUCKET</key>
 	<string>hi-lingual-de607.firebasestorage.app</string>
 	<key>IS_ADS_ENABLED</key>
-	<false></false>
+	<false/>
 	<key>IS_ANALYTICS_ENABLED</key>
-	<false></false>
+	<false/>
 	<key>IS_APPINVITE_ENABLED</key>
-	<true></true>
+	<true/>
 	<key>IS_GCM_ENABLED</key>
-	<true></true>
+	<true/>
 	<key>IS_SIGNIN_ENABLED</key>
-	<true></true>
+	<true/>
 	<key>GOOGLE_APP_ID</key>
 	<string>1:414802359007:ios:bdb2b96bb089286370af6a</string>
 </dict>

--- a/HilingualCore/Package.resolved
+++ b/HilingualCore/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "7c0d4bb322b5bb8abd804ee8f8c8b0aa488a384eec13d4d14150376dcef9aa23",
+  "pins" : [
+    {
+      "identity" : "amplitude-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/Amplitude-Swift",
+      "state" : {
+        "revision" : "50189dc0f00e22b12435b1679150a4d48e165495",
+        "version" : "1.18.5"
+      }
+    },
+    {
+      "identity" : "amplitudecore-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/AmplitudeCore-Swift.git",
+      "state" : {
+        "revision" : "5390ca68565f7e0326eca5d709e0d955d641727c",
+        "version" : "1.4.7"
+      }
+    },
+    {
+      "identity" : "analytics-connector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/analytics-connector-ios.git",
+      "state" : {
+        "revision" : "4adbfe85486e6dcdcdca5fa9362097ffe5ec712b",
+        "version" : "1.3.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/HilingualCore/Sources/HilingualCore/Analytics/AmplitudeManager.swift
+++ b/HilingualCore/Sources/HilingualCore/Analytics/AmplitudeManager.swift
@@ -40,7 +40,7 @@ public final class AmplitudeManager: @unchecked Sendable {
             return
         }
 
-        let configuration = Configuration(apiKey: apiKey)
+        let configuration = Configuration(apiKey: apiKey, minIdLength: 1)
         configuration.defaultTracking.sessions = true
         configuration.defaultTracking.screenViews = true
 
@@ -74,9 +74,30 @@ public final class AmplitudeManager: @unchecked Sendable {
     }
 
     public func setUserId(_ userId: String?) {
-        guard ensureInitialized() else { return }
+        guard ensureInitialized() else {
+            #if DEBUG
+            print("[Amplitude] ⚠️ setUserId 무시됨 — 미초기화 (userId: \(String(describing: userId)))")
+            #endif
+            return
+        }
 
         amplitude?.setUserId(userId: userId)
+        #if DEBUG
+        print("[Amplitude] ✅ setUserId = \(String(describing: userId))")
+        #endif
+    }
+
+    /// 서버 userId(Long)를 Amplitude userId로 설정한다.
+    public func updateUserId(_ userId: Int64) {
+        #if DEBUG
+        print("[Amplitude] 📥 updateUserId(\(userId)) 호출됨")
+        #endif
+        setUserId(String(userId))
+    }
+
+    /// 로그아웃/탈퇴 시 userId를 해제한다.
+    public func clearUserId() {
+        setUserId(nil)
     }
 
     public func setUserProperty(key: String, value: Any) {

--- a/HilingualCore/Sources/HilingualCore/Analytics/CrashReporter.swift
+++ b/HilingualCore/Sources/HilingualCore/Analytics/CrashReporter.swift
@@ -1,0 +1,29 @@
+//
+//  CrashReporter.swift
+//  HilingualCore
+//
+//  Created by 성현주 on 6/27/26.
+//
+
+// 크래시/비치명(non-fatal) 에러 리포팅 추상화.
+// 구현(Crashlytics 등)은 앱 타겟에서 주입한다. Core/Network/Presentation 은 Firebase에 의존하지 않는다.
+
+import Foundation
+
+public protocol CrashReporting: AnyObject {
+    func record(_ error: Error, userInfo: [String: String])
+    func log(_ message: String)
+}
+
+public enum CrashReporter {
+
+    nonisolated(unsafe) public static var reporter: CrashReporting?
+
+    public static func record(_ error: Error, userInfo: [String: String] = [:]) {
+        reporter?.record(error, userInfo: userInfo)
+    }
+
+    public static func log(_ message: String) {
+        reporter?.log(message)
+    }
+}

--- a/HilingualData/Sources/HilingualData/Mapper/LoginResponseDTO+Mapper.swift
+++ b/HilingualData/Sources/HilingualData/Mapper/LoginResponseDTO+Mapper.swift
@@ -13,6 +13,7 @@ import HilingualNetwork
 extension LoginResponseDTO {
     public func toEntity() -> LoginResponseEntity {
         return LoginResponseEntity(
+            userId: self.userId,
             accessToken: self.accessToken,
             refreshToken: self.refreshToken,
             isProfileCompleted: self.registerStatus

--- a/HilingualData/Sources/HilingualData/Mapper/UserProfileResponseDTO+Mapper.swift
+++ b/HilingualData/Sources/HilingualData/Mapper/UserProfileResponseDTO+Mapper.swift
@@ -13,6 +13,7 @@ import HilingualDomain
 extension UserProfileResponseDTO {
     public func toEntity() -> UserProfileEntity {
         return UserProfileEntity(
+            userId: self.userId,
             profileImg: self.profileImg,
             nickname: self.nickname,
             provider: self.provider

--- a/HilingualData/Sources/HilingualData/Repository/DefaultOnBoardingRepository.swift
+++ b/HilingualData/Sources/HilingualData/Repository/DefaultOnBoardingRepository.swift
@@ -27,7 +27,7 @@ public final class DefaultOnBoardingRepository: OnBoardingRepository {
             .eraseToAnyPublisher()
     }
 
-    public func registerProfile(profile: ProfileEntity) -> AnyPublisher<Void, Error> {
+    public func registerProfile(profile: ProfileEntity) -> AnyPublisher<Int64, Error> {
         return service.registerProfile(
             nickname: profile.nickname,
             adAlarmAgree: profile.adAlarmAgree,

--- a/HilingualDomain/Sources/HilingualDomain/Entity/LoginResponseEntity.swift
+++ b/HilingualDomain/Sources/HilingualDomain/Entity/LoginResponseEntity.swift
@@ -8,15 +8,18 @@
 import Foundation
 
 public struct LoginResponseEntity {
+    public let userId: Int64?
     public let accessToken: String
     public let refreshToken: String
     public let isProfileCompleted: Bool?
 
     public init(
+        userId: Int64? = nil,
         accessToken: String,
         refreshToken: String,
         isProfileCompleted: Bool? = nil
     ) {
+        self.userId = userId
         self.accessToken = accessToken
         self.refreshToken = refreshToken
         self.isProfileCompleted = isProfileCompleted

--- a/HilingualDomain/Sources/HilingualDomain/Entity/UserProfileEntity.swift
+++ b/HilingualDomain/Sources/HilingualDomain/Entity/UserProfileEntity.swift
@@ -6,11 +6,13 @@
 //
 
 public struct UserProfileEntity {
+    public let userId: Int64?
     public let profileImg: String
     public let nickname: String
     public let provider: String
-    
-    public init(profileImg: String, nickname: String, provider: String) {
+
+    public init(userId: Int64?, profileImg: String, nickname: String, provider: String) {
+        self.userId = userId
         self.profileImg = profileImg
         self.nickname = nickname
         self.provider = provider

--- a/HilingualDomain/Sources/HilingualDomain/Interface/Repository/OnBoardingRepository.swift
+++ b/HilingualDomain/Sources/HilingualDomain/Interface/Repository/OnBoardingRepository.swift
@@ -10,6 +10,6 @@ import Combine
 
 public protocol OnBoardingRepository {
     func isNicknameAvailable(_ nickname: String) -> AnyPublisher<(Bool, String?), Never>
-    func registerProfile(profile: ProfileEntity) -> AnyPublisher<Void, Error>
+    func registerProfile(profile: ProfileEntity) -> AnyPublisher<Int64, Error>
 }
 

--- a/HilingualDomain/Sources/HilingualDomain/UseCase/OnBoardingUseCase.swift
+++ b/HilingualDomain/Sources/HilingualDomain/UseCase/OnBoardingUseCase.swift
@@ -11,7 +11,7 @@ import Combine
 public protocol OnBoardingUseCase {
     func validate(_ nickname: String) -> NicknameValidationResult
     func checkDuplicate(_ nickname: String) -> AnyPublisher<(Bool, String?), Never>
-    func registerProfile(nickname: String, adAlarmAgree: Bool, fileKey: String?) -> AnyPublisher<Void, Error>
+    func registerProfile(nickname: String, adAlarmAgree: Bool, fileKey: String?) -> AnyPublisher<Int64, Error>
 }
 
 public final class DefaultOnBoardingUseCase: OnBoardingUseCase {
@@ -38,7 +38,7 @@ public final class DefaultOnBoardingUseCase: OnBoardingUseCase {
         return onBoardingRepository.isNicknameAvailable(nickname)
     }
 
-    public func registerProfile(nickname: String, adAlarmAgree: Bool, fileKey: String?) -> AnyPublisher<Void, Error> {
+    public func registerProfile(nickname: String, adAlarmAgree: Bool, fileKey: String?) -> AnyPublisher<Int64, Error> {
         let entity = ProfileEntity(nickname: nickname, adAlarmAgree: adAlarmAgree, fileKey: fileKey)
            return onBoardingRepository.registerProfile(profile: entity)
        }

--- a/HilingualNetwork/Sources/HilingualNetwork/DTO/LoginResponseDTO.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/DTO/LoginResponseDTO.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public struct LoginResponseDTO: Decodable {
+    public let userId: Int64?
     public let accessToken: String
     public let refreshToken: String
     public let registerStatus: Bool

--- a/HilingualNetwork/Sources/HilingualNetwork/DTO/OnBoardingReponseDTO.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/DTO/OnBoardingReponseDTO.swift
@@ -21,6 +21,10 @@ public struct NicknameAvailabilityDTO: Decodable {
 
 // MARK: - RegisterProfile
 
+public struct RegisterProfileResponseDTO: Decodable {
+    public let userId: Int64
+}
+
 public struct RegisterProfileRequestDTO: Encodable {
     public let nickname: String
     public let adAlarmAgree: Bool

--- a/HilingualNetwork/Sources/HilingualNetwork/DTO/UserProfileResponseDTO.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/DTO/UserProfileResponseDTO.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public struct UserProfileResponseDTO: Decodable {
+    public let userId: Int64?
     public let profileImg: String
     public let nickname: String
     public let provider: String

--- a/HilingualNetwork/Sources/HilingualNetwork/Foundation/BaseService.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/Foundation/BaseService.swift
@@ -37,6 +37,30 @@ public class BaseService<API: TargetType> {
         return nil
     }
 
+    // MARK: - Crash Reporting
+
+    private static func report(_ error: NetworkError, path: String) {
+        let code: Int
+        switch error {
+        case .serverError(let serverError): code = serverError.code
+        case .decoding: code = -1001
+        case .networkFail: code = -1002
+        case .timeout: code = -1003
+        case .forbidden: code = 403
+        case .unauthorized: code = 401
+        case .notFound: code = 404
+        case .refreshFailed: code = -1004
+        case .unknown: code = -1000
+        }
+
+        let nsError = NSError(
+            domain: "API.\(API.self)",
+            code: code,
+            userInfo: [NSLocalizedDescriptionKey: "\(error)"]
+        )
+        CrashReporter.record(nsError, userInfo: ["path": path, "error": "\(error)"])
+    }
+
     // MARK: - Properties
 
     private let provider: MoyaProvider<API>
@@ -76,8 +100,12 @@ public class BaseService<API: TargetType> {
                             }
 
                         case 500..<600:
-                            promise(.failure(.serverError(ServerError(code: response.statusCode,
-                                                                      message: "Server Error"))))
+                            if let serverError = try? JSONDecoder().decode(ServerError.self, from: response.data) {
+                                promise(.failure(.serverError(serverError)))
+                            } else {
+                                promise(.failure(.serverError(ServerError(code: response.statusCode,
+                                                                          message: "Server Error"))))
+                            }
 
                         default:
                             promise(.failure(.unknown))
@@ -99,6 +127,7 @@ public class BaseService<API: TargetType> {
         .handleEvents(receiveCompletion: { completion in
             if case .failure(let error) = completion {
                 print("❌ [네트워크에러] \(API.self) - \(target.path): \(error)에러 발생 ㅠ")
+                Self.report(error, path: target.path)
             }
         })
         .mapError { $0.toHilingualError() }
@@ -130,8 +159,12 @@ public class BaseService<API: TargetType> {
                         }
 
                     case 500..<600:
-                        promise(.failure(.serverError(ServerError(code: response.statusCode,
-                                                                  message: "Server Error"))))
+                        if let serverError = try? JSONDecoder().decode(ServerError.self, from: response.data) {
+                            promise(.failure(.serverError(serverError)))
+                        } else {
+                            promise(.failure(.serverError(ServerError(code: response.statusCode,
+                                                                      message: "Server Error"))))
+                        }
 
                     default:
                         promise(.failure(.unknown))
@@ -146,6 +179,11 @@ public class BaseService<API: TargetType> {
                 }
             }
         }
+        .handleEvents(receiveCompletion: { completion in
+            if case .failure(let error) = completion {
+                Self.report(error, path: target.path)
+            }
+        })
         .mapError { $0.toHilingualError() }
         .eraseToAnyPublisher()
     }

--- a/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultOnBoardingService.swift
+++ b/HilingualNetwork/Sources/HilingualNetwork/Service/DefaultOnBoardingService.swift
@@ -12,22 +12,16 @@ import Combine
 
 public protocol OnBoardingService {
     func checkNicknameDuplication(nickname: String) -> AnyPublisher<OnBoardingResponseDTO, Error>
-    func registerProfile(nickname: String, adAlarmAgree: Bool, fileKey: String?) -> AnyPublisher<Void, Error>
+    func registerProfile(nickname: String, adAlarmAgree: Bool, fileKey: String?) -> AnyPublisher<Int64, Error>
 }
 
 public final class DefaultOnBoardingService: BaseService<OnBoardingAPI>, OnBoardingService {
-    public func registerProfile(nickname: String, adAlarmAgree: Bool, fileKey: String?) -> AnyPublisher<Void, Error> {
-//        #if DEBUG
-//        return Just(())
-//            .setFailureType(to: Error.self)
-//            .eraseToAnyPublisher()
-//        #else
+    public func registerProfile(nickname: String, adAlarmAgree: Bool, fileKey: String?) -> AnyPublisher<Int64, Error> {
         let dto = RegisterProfileRequestDTO(nickname: nickname, adAlarmAgree: adAlarmAgree, fileKey: fileKey)
-        return requestPlain(.registerProfile(requestDTO: dto))
-            .map { _ in () }
+        return request(.registerProfile(requestDTO: dto), as: BaseAPIResponse<RegisterProfileResponseDTO>.self)
+            .map { $0.data.userId }
             .mapError { $0 as Error }
             .eraseToAnyPublisher()
-//        #endif
     }
 
     public func checkNicknameDuplication(nickname: String) -> AnyPublisher<OnBoardingResponseDTO, Error> {

--- a/HilingualPresentation/Sources/Presentation/Debug/DebugViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Debug/DebugViewController.swift
@@ -15,14 +15,23 @@ public final class DebugViewController: UIViewController {
     private struct Item {
         let title: String
         let subtitle: String
-        let make: () -> UIViewController
+        let handler: (DebugViewController) -> Void
     }
 
     private let items: [Item] = [
         Item(
             title: "강제 에러",
             subtitle: "화면별 서버/네트워크/데이터없음 에러 강제",
-            make: { DebugForceErrorViewController() }
+            handler: { vc in
+                vc.navigationController?.pushViewController(DebugForceErrorViewController(), animated: true)
+            }
+        ),
+        Item(
+            title: "💥 강제 크래시 (Crashlytics 테스트)",
+            subtitle: "탭 시 즉시 크래시 → 디버거 없이 재실행하면 Crashlytics로 전송",
+            handler: { _ in
+                fatalError("Crashlytics 테스트용 강제 크래시")
+            }
         )
     ]
 
@@ -74,7 +83,7 @@ extension DebugViewController: UITableViewDataSource, UITableViewDelegate {
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        navigationController?.pushViewController(items[indexPath.row].make(), animated: true)
+        items[indexPath.row].handler(self)
     }
 }
 #endif

--- a/HilingualPresentation/Sources/Presentation/Login/LoginViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/Login/LoginViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import HilingualCore
 import HilingualDomain
 
 public final class LoginViewModel: BaseViewModel {
@@ -102,6 +103,11 @@ public final class LoginViewModel: BaseViewModel {
 
         HomeRecoveryStorage.clearSessionCache()
         saveLoginState(result)
+        if let userId = result.userId {
+            Task { @MainActor in
+                AmplitudeManager.shared.updateUserId(userId)
+            }
+        }
         navigateAfterLogin(result)
     }
 

--- a/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageViewController.swift
@@ -62,7 +62,7 @@ public final class MypageViewController: BaseUIViewController<MypageViewModel> {
         mypageView.logoutButton.addTarget(self, action: #selector(presentLogoutDialog), for: .touchUpInside)
         mypageView.editButton.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
         mypageView.feedButton.addTarget(self, action: #selector(myFeedProfileButtonTapped), for: .touchUpInside)
-        
+
         mypageView.onEditProfileTap = { [weak self] in
             self?.editButtonTapped()
         }
@@ -146,7 +146,7 @@ public final class MypageViewController: BaseUIViewController<MypageViewModel> {
     }
     
     // MARK: - Private Methods
-    
+
     @objc
     private func presentLogoutDialog() {
         guard let window = UIApplication.shared.windows.first else { return }

--- a/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/MyPage/MypageHome/MypageViewModel.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import Foundation
+import HilingualCore
 import HilingualDomain
 
 public final class MypageViewModel: BaseViewModel {
@@ -86,6 +87,11 @@ public final class MypageViewModel: BaseViewModel {
                 },
                 receiveValue: { [weak self] profile in
                     self?.userProfileSubject.send(profile)
+                    if let userId = profile.userId {
+                        Task { @MainActor in
+                            AmplitudeManager.shared.updateUserId(userId)
+                        }
+                    }
                 }
             )
             .store(in: &cancellables)

--- a/HilingualPresentation/Sources/Presentation/OnBoarding/OnBoardingViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/OnBoarding/OnBoardingViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import HilingualCore
 import HilingualDomain
 
 public final class OnBoardingViewModel: BaseViewModel {
@@ -133,7 +134,7 @@ public final class OnBoardingViewModel: BaseViewModel {
     private func signUpWithImage(data: Data, adAgree: Bool) -> AnyPublisher<Void, Never> {
         uploadImageUseCase
             .execute(data: data, contentType: "image/jpeg", purpose: "PROFILE_UPLOAD")
-            .flatMap { [weak self] fileKey -> AnyPublisher<Void, Error> in
+            .flatMap { [weak self] fileKey -> AnyPublisher<Int64, Error> in
                 guard let self else {
                     return Fail(error: NSError(domain: "OnBoardingViewModel", code: -1)).eraseToAnyPublisher()
                 }
@@ -144,16 +145,17 @@ public final class OnBoardingViewModel: BaseViewModel {
                     fileKey: fileKey
                 )
             }
-            .flatMap { [weak self] _ -> AnyPublisher<Void, Error> in
+            .flatMap { [weak self] userId -> AnyPublisher<Int64, Error> in
                 guard let self else {
                     return Fail(error: NSError(domain: "OnBoardingViewModel", code: -1)).eraseToAnyPublisher()
                 }
 
-                return self.syncDeviceAfterSignUp()
+                return self.syncDeviceAfterSignUp().map { userId }.eraseToAnyPublisher()
             }
-            .handleEvents(receiveOutput: { [weak self] in
-                self?.handleSignUpSuccess()
+            .handleEvents(receiveOutput: { [weak self] userId in
+                self?.handleSignUpSuccess(userId: userId)
             })
+            .map { _ in () }
             .catch { [weak self] error -> Empty<Void, Never> in
                 self?.signUpErrorSubject.send(error)
                 return Empty<Void, Never>()
@@ -167,16 +169,17 @@ public final class OnBoardingViewModel: BaseViewModel {
             adAlarmAgree: adAgree,
             fileKey: nil
         )
-        .flatMap { [weak self] _ -> AnyPublisher<Void, Error> in
+        .flatMap { [weak self] userId -> AnyPublisher<Int64, Error> in
             guard let self else {
                 return Fail(error: NSError(domain: "OnBoardingViewModel", code: -1)).eraseToAnyPublisher()
             }
 
-            return self.syncDeviceAfterSignUp()
+            return self.syncDeviceAfterSignUp().map { userId }.eraseToAnyPublisher()
         }
-        .handleEvents(receiveOutput: { [weak self] in
-            self?.handleSignUpSuccess()
+        .handleEvents(receiveOutput: { [weak self] userId in
+            self?.handleSignUpSuccess(userId: userId)
         })
+        .map { _ in () }
         .catch { [weak self] error -> Empty<Void, Never> in
             self?.signUpErrorSubject.send(error)
             return Empty<Void, Never>()
@@ -184,8 +187,11 @@ public final class OnBoardingViewModel: BaseViewModel {
         .eraseToAnyPublisher()
     }
 
-    private func handleSignUpSuccess() {
+    private func handleSignUpSuccess(userId: Int64) {
         UserDefaults.standard.set(true, forKey: "isProfileCompleted")
+        Task { @MainActor in
+            AmplitudeManager.shared.updateUserId(userId)
+        }
         navigateToHomeSubject.send()
     }
 


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #이슈번호

---

## 📎 Work Description 
분석/관측(Analytics & Observability) 파이프라인을 Android와 동일한 수준으로 맞췄습니다.
1. **Amplitude userId 매핑** — 서버 `userId(Long)`를 Amplitude `user_id`로 연결
2. **에러 CTA Amplitude 이벤트** — 에러 화면의 버튼 클릭을 이벤트로 수집
3. **Firebase Crashlytics + Analytics 연동** — 크래시/오류를 Crashlytics에 기록 → Slack 알림

> 2·3번은 에러 처리 정책 PR(#435)의 `ErrorPresenter`/`BaseService` choke-point 위에서 동작합니다. (해당 PR 이후 머지 예정)

---

### 1. Amplitude userId 매핑

서버가 **소셜로그인 / 회원가입 프로필 등록 / 내정보 확인** 응답에 `userId(Long)`를 추가함에 따라, 이를 Amplitude user_id로 설정합니다.

### 세팅 지점 (코호트별)
| 진입 | 출처 | 위치 |
|---|---|---|
| 기존 유저 소셜 로그인 | 로그인 응답 `userId` | `LoginViewModel` |
| 신규 유저 가입 | 프로필 등록 응답 `userId` | `OnBoardingViewModel` |
| 자동 로그인 후 / 기존 유저 | 내정보(mypage/info) 응답 `userId` | `MypageViewModel` |

- **자동 로그인(reissue)** 응답엔 userId가 없으므로(백엔드 미제공), 해당 유저는 **MyPage 진입 시 백필**됩니다.
- **로컬 저장 없음** — Amplitude SDK가 user_id를 자체 영속화하므로 별도 UserDefaults 캐싱 불필요. (`clearUserId()`는 로그아웃용으로 제공)
- **`minIdLength = 1`** — Amplitude 기본 규칙(user_id ≥ 5자)에 막혀 짧은 숫자 id가 **400(Invalid id length)으로 거부**되던 문제 해결.

### 데이터 흐름 변경
- `UserProfileResponseDTO`/`UserProfileEntity`/mapper에 `userId: Int64?` 추가 (mypage/info)
- `LoginResponseDTO`/`LoginResponseEntity`/mapper에 `userId: Int64?` 추가 (소셜 로그인)
- `RegisterProfileResponseDTO` 신규 + OnBoarding 체인(Service/Repository/UseCase) `Void → Int64` (가입 시 `requestPlain` → `request`로 응답 수신)
- `TokenRefreshResponseDTO`는 userId 없음 → 미적용
- `AmplitudeManager.updateUserId(Int64)` / `clearUserId()` 추가

---

### 2. 에러 CTA Amplitude 이벤트

에러 화면의 CTA 버튼 클릭을 수집합니다. **버튼을 실제로 탭했을 때만** 발화(화면 노출 시점엔 미발화).

| 버튼 | 이벤트 action |
|---|---|
| 다시 시도(서버) | `server_error_retry` |
| 다시 시도(네트워크) | `network_error_retry` |
| 이전 페이지로 돌아가기 / 단어장 확인 | `data_not_found_go_back` |
| 뒤로가기(좌상단) | 서버 `server_error_go_back` / 데이터없음 `data_not_found_go_back` |
| 모달 확인 | 서버 `server_error_confirm` |
| 피드백 다시 요청하기 | `feedback_retry` |

---

### 3. Firebase Crashlytics + Analytics 연동

크래시·오류 모니터링을 추가하고 Slack으로 알림이 가도록 연동했습니다. 

### 수집 정책
| 종류 | Debug | Release |
|---|---|---|
| 크래시(fatal) | 자동 | 자동 |
| 비치명 API 오류(non-fatal) | 안감 | 전달 |

- **크래시**: `FirebaseApp.configure()`로 양쪽 빌드 자동 수집.
- **비치명 API 오류**: `BaseService` choke-point에서 **모든 실패를 기록**(에러 코드 필터 없음 — Android `Timber.e → ReleaseTree.recordException`와 동일). **RELEASE 빌드에서만** 전송(한 Firebase 프로젝트 + 프로젝트 단위 Slack이라 dev 노이즈 방지).
- 5xx 응답 본문을 디코딩해 `50302`(GPT)·`50304`(S3) 등 **세부 코드로 그룹핑**.

### 구조 (모듈 경계 유지)
- `CrashReporting` 프로토콜 + `CrashReporter`(HilingualCore, **Firebase 비의존**) — Network/Presentation은 추상화만 호출
- `FirebaseCrashReporter`(App 타겟) — Crashlytics 구현체를 `#if !DEBUG`에서 주입
- `BaseService.report(...)` — non-fatal을 `NSError(domain: "API.<API>", code:, userInfo: [path, error])`로 기록 → 도메인/코드별 그룹핑

---

## 📷 Screenshots  

| 기능/화면 | iPhone SE | iPhone 16 Pro |
|:---------:|:---------:|:-------------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/8a473f83-4996-4097-a77f-245c9e19d294" width="250"> | <img src="https://github.com/user-attachments/assets/f05c7f7b-c035-4f64-ab67-96f10270c56c" width="250"> |


---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
