### PR TITLE
[hotfix] #438 FCM 및 딥링크 관련 오류 해결

### DIFF
--- a/Hilingual.xcodeproj/project.pbxproj
+++ b/Hilingual.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		E5C84AC92E1538C700CBD669 /* AppDIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C84AC82E1538C700CBD669 /* AppDIContainer.swift */; };
 		E5CBCFB42EC4B3E100475E81 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = E5CBCFB32EC4B3E100475E81 /* FirebaseCore */; };
 		E5CBCFB62EC4B3E100475E81 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = E5CBCFB52EC4B3E100475E81 /* FirebaseRemoteConfig */; };
-		E5CBCFB82EC4B4C900475E81 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E5CBCFB72EC4B4C900475E81 /* GoogleService-Info.plist */; };
 		E5D5D0A92E171AC300DABE8D /* HilingualData in Frameworks */ = {isa = PBXBuildFile; productRef = E5D5D0A82E171AC300DABE8D /* HilingualData */; };
 		E5D5D0AC2E17289000DABE8D /* HilingualPresentation in Frameworks */ = {isa = PBXBuildFile; productRef = E5D5D0AB2E17289000DABE8D /* HilingualPresentation */; };
 /* End PBXBuildFile section */
@@ -57,7 +56,8 @@
 		E5C79B292E15282100E461C3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E5C79B2D2E15282100E461C3 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E5C84AC82E1538C700CBD669 /* AppDIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDIContainer.swift; sourceTree = "<group>"; };
-		E5CBCFB72EC4B4C900475E81 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		E5CBCFB72EC4B4C900475E81 /* GoogleService-Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Debug.plist"; sourceTree = "<group>"; };
+		E5CBCFB82EC4B4C900475E81 /* GoogleService-Info-Release.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Release.plist"; sourceTree = "<group>"; };
 		E5D5D0A72E171AA900DABE8D /* HilingualData */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = HilingualData; sourceTree = "<group>"; };
 		E5D5D0AA2E1727BB00DABE8D /* HilingualPresentation */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = HilingualPresentation; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -130,7 +130,8 @@
 				E5C79B3B2E152AC800E461C3 /* App */,
 				E51DB2002E1CF7AD000C2BEA /* Hilingual.entitlements */,
 				E5C79B282E15282100E461C3 /* Info.plist */,
-				E5CBCFB72EC4B4C900475E81 /* GoogleService-Info.plist */,
+				E5CBCFB72EC4B4C900475E81 /* GoogleService-Info-Debug.plist */,
+				E5CBCFB82EC4B4C900475E81 /* GoogleService-Info-Release.plist */,
 			);
 			path = Hilingual;
 			sourceTree = "<group>";
@@ -157,6 +158,7 @@
 				E5C79B0A2E15281900E461C3 /* Sources */,
 				E5C79B0B2E15281900E461C3 /* Frameworks */,
 				E5C79B0C2E15281900E461C3 /* Resources */,
+				E5F1A0012FCB000100000001 /* Configure Firebase */,
 				E5151C022E15DEA700497996 /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -228,7 +230,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				E51B4C542E28DC11000B16D0 /* AppIcon.xcassets in Resources */,
-				E5CBCFB82EC4B4C900475E81 /* GoogleService-Info.plist in Resources */,
 				E5C79B322E15282100E461C3 /* LaunchScreen.storyboard in Resources */,
 				3A091AEA2F8F923E004D27CF /* Debug.xcconfig in Resources */,
 				3A091AE82F8F922B004D27CF /* Release.xcconfig in Resources */,
@@ -236,6 +237,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		E5F1A0012FCB000100000001 /* Configure Firebase */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Hilingual/GoogleService-Info-Debug.plist",
+				"$(SRCROOT)/Hilingual/GoogleService-Info-Release.plist",
+			);
+			name = "Configure Firebase";
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\n\ncase \"${CONFIGURATION}\" in\n  Debug) FIREBASE_PLIST=\"${SRCROOT}/Hilingual/GoogleService-Info-Debug.plist\" ;;\n  Release) FIREBASE_PLIST=\"${SRCROOT}/Hilingual/GoogleService-Info-Release.plist\" ;;\n  *) echo \"error: Unsupported configuration ${CONFIGURATION}\" >&2; exit 1 ;;\nesac\n\nDESTINATION=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleService-Info.plist\"\nmkdir -p \"$(dirname \"${DESTINATION}\")\"\ncp \"${FIREBASE_PLIST}\" \"${DESTINATION}\"\n\necho \"Configured Firebase for ${CONFIGURATION}: ${FIREBASE_PLIST}\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		E5C79B0A2E15281900E461C3 /* Sources */ = {

--- a/Hilingual/App/AppDelegate.swift
+++ b/Hilingual/App/AppDelegate.swift
@@ -61,41 +61,43 @@ extension AppDelegate: MessagingDelegate {
         }
     }
 }
-
 extension AppDelegate: UNUserNotificationCenterDelegate {
-
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification
-    ) async -> UNNotificationPresentationOptions {
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         let userInfo = notification.request.content.userInfo
         print("🔔 [앱 포그라운드] 푸시 수신!")
         print("📱 제목: \(notification.request.content.title)")
         print("📱 본문: \(notification.request.content.body)")
         print("📱 데이터: \(userInfo)")
-
-        return [.banner, .sound, .badge]
+        
+        completionHandler([.banner, .sound, .badge])
     }
 
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse
-    ) async {
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
         let userInfo = response.notification.request.content.userInfo
         print("🔔 [푸시 탭됨!]")
         print("📱 전체 데이터: \(userInfo)")
-
+        
         guard let link = userInfo["link"] as? String,
               let url = URL(string: link),
               let destination = DeeplinkParser.parse(url: url) else {
             print("⚠️ link 파싱 실패")
+            completionHandler()
             return
         }
 
         print("[Deeplink] 푸시 탭 → \(destination)")
 
-        await MainActor.run {
+        Task { @MainActor in
             DeeplinkManager.shared.pendingDestination = destination
         }
+        
+        completionHandler()
     }
 }

--- a/Hilingual/App/AppDelegate.swift
+++ b/Hilingual/App/AppDelegate.swift
@@ -66,23 +66,21 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) {
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
         let userInfo = notification.request.content.userInfo
         print("🔔 [앱 포그라운드] 푸시 수신!")
         print("📱 제목: \(notification.request.content.title)")
         print("📱 본문: \(notification.request.content.body)")
         print("📱 데이터: \(userInfo)")
 
-        completionHandler([.banner, .sound, .badge])
+        return [.banner, .sound, .badge]
     }
 
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse,
-        withCompletionHandler completionHandler: @escaping () -> Void
-    ) {
+        didReceive response: UNNotificationResponse
+    ) async {
         let userInfo = response.notification.request.content.userInfo
         print("🔔 [푸시 탭됨!]")
         print("📱 전체 데이터: \(userInfo)")
@@ -91,16 +89,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
               let url = URL(string: link),
               let destination = DeeplinkParser.parse(url: url) else {
             print("⚠️ link 파싱 실패")
-            completionHandler()
             return
         }
 
         print("[Deeplink] 푸시 탭 → \(destination)")
 
-        Task { @MainActor in
+        await MainActor.run {
             DeeplinkManager.shared.pendingDestination = destination
         }
-
-        completionHandler()
     }
 }

--- a/Hilingual/App/AppDelegate.swift
+++ b/Hilingual/App/AppDelegate.swift
@@ -66,6 +66,12 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
+        let userInfo = notification.request.content.userInfo
+        print("🔔 [앱 포그라운드] 푸시 수신!")
+        print("📱 제목: \(notification.request.content.title)")
+        print("📱 본문: \(notification.request.content.body)")
+        print("📱 데이터: \(userInfo)")
+        
         return [.banner, .sound, .badge]
     }
 
@@ -74,9 +80,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse
     ) async {
         let userInfo = response.notification.request.content.userInfo
+        print("🔔 [푸시 탭됨!]")
+        print("📱 전체 데이터: \(userInfo)")
+        
         guard let link = userInfo["link"] as? String,
               let url = URL(string: link),
-              let destination = DeeplinkParser.parse(url: url) else { return }
+              let destination = DeeplinkParser.parse(url: url) else {
+            print("⚠️ link 파싱 실패")
+            return
+        }
 
         print("[Deeplink] 푸시 탭 → \(destination)")
 

--- a/Hilingual/App/AppDelegate.swift
+++ b/Hilingual/App/AppDelegate.swift
@@ -61,39 +61,46 @@ extension AppDelegate: MessagingDelegate {
         }
     }
 }
+
 extension AppDelegate: UNUserNotificationCenterDelegate {
+
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification
-    ) async -> UNNotificationPresentationOptions {
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
         let userInfo = notification.request.content.userInfo
         print("🔔 [앱 포그라운드] 푸시 수신!")
         print("📱 제목: \(notification.request.content.title)")
         print("📱 본문: \(notification.request.content.body)")
         print("📱 데이터: \(userInfo)")
-        
-        return [.banner, .sound, .badge]
+
+        completionHandler([.banner, .sound, .badge])
     }
 
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse
-    ) async {
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
         let userInfo = response.notification.request.content.userInfo
         print("🔔 [푸시 탭됨!]")
         print("📱 전체 데이터: \(userInfo)")
-        
+
         guard let link = userInfo["link"] as? String,
               let url = URL(string: link),
               let destination = DeeplinkParser.parse(url: url) else {
             print("⚠️ link 파싱 실패")
+            completionHandler()
             return
         }
 
         print("[Deeplink] 푸시 탭 → \(destination)")
 
-        await MainActor.run {
+        Task { @MainActor in
             DeeplinkManager.shared.pendingDestination = destination
         }
+
+        completionHandler()
     }
 }

--- a/Hilingual/GoogleService-Info-Debug.plist
+++ b/Hilingual/GoogleService-Info-Debug.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyAumxzjHdUou4ePTIw9KxStEJbxX2FoYc4</string>
+	<key>GCM_SENDER_ID</key>
+	<string>414802359007</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.Hilingual.dev</string>
+	<key>PROJECT_ID</key>
+	<string>hi-lingual-de607</string>
+	<key>STORAGE_BUCKET</key>
+	<string>hi-lingual-de607.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false/>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false/>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true/>
+	<key>IS_GCM_ENABLED</key>
+	<true/>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true/>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:414802359007:ios:9bc0861821aad4d570af6a</string>
+</dict>
+</plist>

--- a/Hilingual/GoogleService-Info-Release.plist
+++ b/Hilingual/GoogleService-Info-Release.plist
@@ -15,15 +15,15 @@
 	<key>STORAGE_BUCKET</key>
 	<string>hi-lingual-de607.firebasestorage.app</string>
 	<key>IS_ADS_ENABLED</key>
-	<false></false>
+	<false/>
 	<key>IS_ANALYTICS_ENABLED</key>
-	<false></false>
+	<false/>
 	<key>IS_APPINVITE_ENABLED</key>
-	<true></true>
+	<true/>
 	<key>IS_GCM_ENABLED</key>
-	<true></true>
+	<true/>
 	<key>IS_SIGNIN_ENABLED</key>
-	<true></true>
+	<true/>
 	<key>GOOGLE_APP_ID</key>
 	<string>1:414802359007:ios:bdb2b96bb089286370af6a</string>
 </dict>

--- a/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Base/TabBarViewController.swift
@@ -91,19 +91,25 @@ public final class TabBarViewController: UIViewController {
 
             let homeNav = self.childNavigationControllers[0]
             DeeplinkManager.shared.handle(destination, from: homeNav, di: self.factory)
-            self.selectTab(at: 0)
+
+            if self.currentIndex != 0 {
+                self.selectTab(at: 0)
+            }
 
             return true
         }
     }
-    
+
     private func handlePendingDeeplink() {
         guard let destination = DeeplinkManager.shared.pendingDestination else { return }
         DeeplinkManager.shared.pendingDestination = nil
-        
+
         let homeNav = childNavigationControllers[0]
         DeeplinkManager.shared.handle(destination, from: homeNav, di: factory)
-        selectTab(at: 0)
+
+        if currentIndex != 0 {
+            selectTab(at: 0)
+        }
     }
 
     private func makeNavigationController(root: UIViewController) -> UINavigationController {

--- a/HilingualPresentation/Sources/Presentation/Common/FCM/FCMTokenManager.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/FCM/FCMTokenManager.swift
@@ -8,6 +8,13 @@
 public final class FCMTokenManager: Sendable {
     public static let shared = FCMTokenManager()
     private init() {}
-    
-    public nonisolated(unsafe) var currentToken: String?
+
+    public nonisolated(unsafe) var onTokenUpdated: ((String) -> Void)?
+
+    public nonisolated(unsafe) var currentToken: String? {
+        didSet {
+            guard let token = currentToken, !token.isEmpty else { return }
+            onTokenUpdated?(token)
+        }
+    }
 }

--- a/HilingualPresentation/Sources/Presentation/Splash/SplashViewModel.swift
+++ b/HilingualPresentation/Sources/Presentation/Splash/SplashViewModel.swift
@@ -48,6 +48,41 @@ public final class SplashViewModel: BaseViewModel {
         self.tokenStore = tokenStore
         self.socialLoginUseCase = socialLoginUseCase
         self.deviceUseCase = deviceUseCase
+        super.init()
+        setupFCMTokenSync()
+    }
+    
+    // MARK: - FCM Token Sync
+    
+    private func setupFCMTokenSync() {
+        FCMTokenManager.shared.onTokenUpdated = { [weak self] token in
+            self?.syncFCMTokenIfNeeded(token)
+        }
+        
+        if let existingToken = FCMTokenManager.shared.currentToken, !existingToken.isEmpty {
+            syncFCMTokenIfNeeded(existingToken)
+        }
+    }
+    
+    private func syncFCMTokenIfNeeded(_ token: String) {
+        let accessToken = tokenStore.loadAccessToken()
+        guard !accessToken.isEmpty else {
+            print("[LoginVM][FCM] 로그인 전 → sync 스킵")
+            return
+        }
+        
+        deviceUseCase.updateFcmToken(fcmToken: token)
+            .sink(
+                receiveCompletion: { completion in
+                    if case let .failure(error) = completion {
+                        print("[LoginVM][FCM] sync 실패: \(error.localizedDescription)")
+                    }
+                },
+                receiveValue: { _ in
+                    print("[LoginVM][FCM] sync 성공")
+                }
+            )
+            .store(in: &cancellables)
     }
 
     // MARK: - Transform


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #438 

---

## 📎 Work Description 
1️⃣ **첫 시작할때 디바이스 토큰이 등록이 안되는 이슈**
  **문제**) 로그인/스플래시 시점에 FCMTokenManager.shared.currentToken이 아직 nil이면 
  updateFcmToken 호출이 스킵되고, 이후 토큰이 도착해도 서버로 보내는 코드가 없어서 디바이스 등록이 누락됨
  
  **해결방법**) FCMTokenManager에 토큰 갱신 시 호출되는 클로저인 onTokenUpdated를 추가하고, 
  SplashViewModel에서 이를 구독하여 토큰이 언제 도착하든 로그인 상태라면 서버로 동기화함

<br>

2️⃣ **딥링크가 동작을 안하는 이슈**
  **문제**) selectTab(at: 0)이 이미 같은 탭일 때도 무조건 재호출되면서 push 애니메이션 중이던 view를 뜯어냈다 다시 붙임
  
  **해결방법**) 이미 홈 탭(index 0)에 있는 상태라면, 굳이 selectTab(0)을 다시 호출할 필요가 없어서 
  TabBarViewController를 수정하여 해결

<br>

3️⃣ **콜드 스타트 상태에서 푸시 딥링크 탭 시 크래시 발생하는 이슈**
  **문제**) AppDelegate의 `didReceive response:`가 async 메서드라 
  시스템이 임의의 백그라운드 스레드에서 실행시킬 수 있는데, 
  이 상태에서 iOS 내부 상태복원 로직이 메인스레드 요구사항과 충돌하며 
  `NSInternalInconsistencyException: Call must be made on main thread` 크래시 발생

  **해결방법**) `didReceive response:`를 completion handler 방식으로 전환하고, 
  pendingDestination 세팅 로직을 `Task { @MainActor in }`로 감싸 메인스레드에서 안전하게 처리되도록 수정

---

## 📷 Screenshots  

| 기능/화면 | 포그라운드 | 백그라운드 |
|:---------:|:---------:|:-------------:|
| 딥링크 | <img src="https://github.com/user-attachments/assets/2b648790-f59a-43b3-872b-5d45b12b72e7" width="250"> | <img src="https://github.com/user-attachments/assets/a63245e0-b886-4ccd-921c-a59d099ce4ff" width="250"> |

---

## 💬 To Reviewers  
- 월요일에 QA라 빠른 코리 부탁드립니다 !
