### PR TITLE
[hotfix] #458 푸시알림 안내 팝업

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -341,7 +341,6 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         }
 
         UserDefaults.standard.set(false, forKey: "showHomeOnboarding")
-        return true
     }
     
     private func showNextHomeModal() {


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #458 

---

## 📎 Work Description 
- 디벨롭 머지 받으며 발생한 컨플릭 해결을 하며 영서가 작업한 일기 스트릭 부활 팝업과 푸시알림 안내 팝업 코드가 겹쳤던 부분에서 에러가 발생했습니다. 그리하여 기존에 반환 타입의 메서드로 인해 return 했던 코드 줄을 삭제하였습니다. 
- 따로 안내 팝업 작업을 하지 않고 이전 팝업이 뜨도록 컨플릭 해결하면서 자연스럽게 팝업 변경이 되었습니다.

---

## 📷 Screenshots  

| 기능/화면 | iPhone SE |
|:---------:|:---------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/59ea669b-82be-41c0-bfa3-4bae7dc507e4" width="250"> |
---

## 💬 To Reviewers  
- 빠.른.코.리
