### PR TITLE
[feat] #461 푸시알림 안내 팝업 변경

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/Home/HomeModalPolicy.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Home/HomeModalPolicy.swift
@@ -1,0 +1,63 @@
+//
+//  HomeModalPolicy.swift
+//  HilingualPresentation
+//
+//  Created by 신혜연 on 8/1/26.
+//
+
+import Foundation
+
+struct HomeModalContext {
+    let today: Date
+    let selectedDate: Date
+    let recoveryTickets: Int
+    let didLoadFilledDates: Bool
+    let filledDates: [Date]
+    let recoveredDates: [Date]
+    let isAlreadyDismissedThisMonth: Bool
+    let isTemporarilyDismissedThisMonth: Bool
+}
+
+enum HomeModalPolicy {
+    case notificationPermission
+    case recoveryStreak(Date)
+
+    static func evaluate(context: HomeModalContext, isNotificationPermissionModalShown: Bool) -> HomeModalPolicy? {
+        if !isNotificationPermissionModalShown {
+            return .notificationPermission
+        }
+
+        let calendar = Calendar.current
+        let lastDay = calendar.range(of: .day, in: .month, for: context.today)?.count ?? 31
+
+        let canShowRecovery = context.didLoadFilledDates
+            && context.recoveryTickets > 0
+            && calendar.isDate(context.selectedDate, equalTo: context.today, toGranularity: .month)
+            && !context.isAlreadyDismissedThisMonth
+            && !context.isTemporarilyDismissedThisMonth
+            && calendar.component(.day, from: context.today) >= lastDay - 7
+
+        if canShowRecovery, let missedDate = fetchRecoveryDate(context: context) {
+            return .recoveryStreak(missedDate)
+        }
+
+        return nil
+    }
+
+    private static func fetchRecoveryDate(context: HomeModalContext) -> Date? {
+        let calendar = Calendar.current
+        let filledKeys = Set(context.filledDates.map { $0.toFormattedString("yyyy-MM-dd") })
+        let recoveredKeys = Set(context.recoveredDates.map { $0.toFormattedString("yyyy-MM-dd") })
+        var date = calendar.date(byAdding: .day, value: -2, to: context.today)
+
+        while let candidate = date,
+              calendar.isDate(candidate, equalTo: context.today, toGranularity: .month) {
+            let key = candidate.toFormattedString("yyyy-MM-dd")
+            if !filledKeys.contains(key), !recoveredKeys.contains(key) {
+                return candidate
+            }
+            date = calendar.date(byAdding: .day, value: -1, to: candidate)
+        }
+        return nil
+    }
+}

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -21,7 +21,6 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     let dialog = Dialog()
     private let homeModal = HomeModal()
     private let notificationPermissionModal = NotificationPermissionModalView()
-    private let activeHomeModal: HomeModalKind = .notificationPermission
     private let input = HomeViewModel.Input()
     private var currentDateRequestCancellable: AnyCancellable?
     private var pendingDraftDate: Date?
@@ -40,11 +39,6 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     private var rewardedInterstitial: RewardedInterstitialAd?
     private var didEarnRecoveryReward = false
     private var recoveryTransitionOverlay: UIView?
-    
-    private enum HomeModalKind {
-        case notificationPermission
-        case recoveryStreak
-    }
     
     // MARK: - Life Cycle
     
@@ -268,24 +262,6 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     }
     
     // MARK: - Private Methods
-    
-    private func checkAndShowNotificationPermissionModal() {
-        guard AppVersionChecker.shouldShowModal else { return }
-        guard let window = self.view.window else { return }
-
-        Task {
-            let isGranted = await fetchNotificationPermission()
-
-            await MainActor.run { [weak self] in
-                guard let self else { return }
-                guard !isGranted else {
-                    AppVersionChecker.markAsShown()
-                    return
-                }
-                self.presentNotificationPermissionModal(on: window)
-            }
-        }
-    }
 
     nonisolated private func fetchNotificationPermission() async -> Bool {
         await withCheckedContinuation { continuation in
@@ -310,17 +286,11 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
 
         notificationPermissionModal.configure(
             laterAction: { [weak self] in
-                AppVersionChecker.markAsShown()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    self?.notificationPermissionModal.removeFromSuperview()
-                }
+                self?.notificationPermissionModal.removeFromSuperview()
             },
             enableAction: { [weak self] in
-                AppVersionChecker.markAsShown()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    self?.notificationPermissionModal.removeFromSuperview()
-                    self?.openSystemSettings()
-                }
+                self?.notificationPermissionModal.removeFromSuperview()
+                self?.openSystemSettings()
             }
         )
         notificationPermissionModal.dialog.showAnimation()
@@ -366,20 +336,39 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     }
     
     private func presentActiveHomeModalIfNeeded() {
-        guard let window = view.window,
+        guard !isShowingOnboardingBottomSheet,
+              !UserDefaults.standard.bool(forKey: "showHomeOnboarding"),
+              let window = view.window,
               !isHomeModalVisible else { return }
 
-        switch activeHomeModal {
+        let context = currentHomeModalContext()
+        let isShown = UserDefaults.standard.bool(forKey: didShowNotificationPermissionModalStorageKey)
+
+        guard let policy = HomeModalPolicy.evaluate(context: context, isNotificationPermissionModalShown: isShown) else {
+            return
+        }
+
+        switch policy {
         case .notificationPermission:
             showNotificationPermissionModalIfNeeded()
-
-        case .recoveryStreak:
-            let today = Date()
-            let selectedDate = homeView.calendarView.selectedDate ?? today
-            guard canShowRecoveryModal(today: today, selectedDate: selectedDate),
-                  let date = mostRecentRecoveryViewDateInCurrentMonth() else { return }
+        case .recoveryStreak(let date):
             showRecoveryModal(for: date)
         }
+    }
+
+    private func currentHomeModalContext() -> HomeModalContext {
+        let today = Date()
+        let currentMonthKey = monthKey(today)
+        return HomeModalContext(
+            today: today,
+            selectedDate: homeView.calendarView.selectedDate ?? today,
+            recoveryTickets: recoveryTickets,
+            didLoadFilledDates: didLoadFilledDates,
+            filledDates: homeView.calendarView.filledDates,
+            recoveredDates: homeView.calendarView.recoveredDates,
+            isAlreadyDismissedThisMonth: UserDefaults.standard.string(forKey: dismissedRecoveryModalMonthStorageKey) == currentMonthKey,
+            isTemporarilyDismissedThisMonth: temporarilyDismissedRecoveryMonth == currentMonthKey
+        )
     }
     
     private func showNotificationPermissionModalIfNeeded() {
@@ -460,41 +449,6 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     private var isHomeModalVisible: Bool {
         (homeModal.superview != nil && !homeModal.isHidden)
         || (notificationPermissionModal.superview != nil && !notificationPermissionModal.isHidden)
-    }
-    
-    private func canShowRecoveryModal(today: Date, selectedDate: Date) -> Bool {
-        let calendar = Calendar.current
-        let lastDay = calendar.range(of: .day, in: .month, for: today)?.count ?? 31
-        let currentMonthKey = monthKey(today)
-        let alreadyDismissed = UserDefaults.standard.string(forKey: dismissedRecoveryModalMonthStorageKey) == currentMonthKey
-        let temporarilyDismissed = temporarilyDismissedRecoveryMonth == currentMonthKey
-        
-        return didLoadFilledDates
-        && recoveryTickets > 0
-        && calendar.isDate(selectedDate, equalTo: today, toGranularity: .month)
-        && !alreadyDismissed
-        && !temporarilyDismissed
-        && calendar.component(.day, from: today) >= lastDay - 7
-    }
-    
-    private func mostRecentRecoveryViewDateInCurrentMonth() -> Date? {
-        let calendar = Calendar.current
-        let today = Date()
-        let filledDateKeys = Set(homeView.calendarView.filledDates.map { dateKey($0) })
-        let recoveredKeys = Set(homeView.calendarView.recoveredDates.map { dateKey($0) })
-        var date = calendar.date(byAdding: .day, value: -2, to: today)
-        
-        while let candidate = date,
-              calendar.isDate(candidate, equalTo: today, toGranularity: .month) {
-            let key = dateKey(candidate)
-            if !filledDateKeys.contains(key), !recoveredKeys.contains(key) {
-                return candidate
-            }
-            
-            date = calendar.date(byAdding: .day, value: -1, to: candidate)
-        }
-        
-        return nil
     }
     
     private func showRecoveryModal(for missedDate: Date) {

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -342,10 +342,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
 
             self.onboardingBottomSheet = nil
             self.isShowingOnboardingBottomSheet = false
-
-            DispatchQueue.main.async {
-                self.showNextHomeModal()
-            }
+            self.showNextHomeModal()
         }
 
         view.window?.addSubview(bottomSheet)

--- a/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
+++ b/HilingualPresentation/Sources/Presentation/Home/HomeViewController.swift
@@ -18,9 +18,10 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     private var onboardingBottomSheet: OnboardingBottomSheet?
     private var overlayView: UIControl?
     private let homeView = HomeView()
-    private let homeModal = HomeModal()
-    private let updateNoticeModal = HomeModal(buttonLabelStyle: .hidden)
     let dialog = Dialog()
+    private let homeModal = HomeModal()
+    private let notificationPermissionModal = NotificationPermissionModalView()
+    private let activeHomeModal: HomeModalKind = .notificationPermission
     private let input = HomeViewModel.Input()
     private var currentDateRequestCancellable: AnyCancellable?
     private var pendingDraftDate: Date?
@@ -34,11 +35,16 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     private var recoveredDateKeys: Set<String> = []
     private let recoveredDateStorageKey = "home.recoveredDateKeys"
     private let dismissedRecoveryModalMonthStorageKey = "home.dismissedRecoveryModalMonth"
-    private let didShowUpdateNoticeModalStorageKey = "home.didShowRecoveryUpdateNoticeModal"
+    private let didShowNotificationPermissionModalStorageKey = "home.didShowNotificationPermissionModal"
     private let localPushPermissionService = LocalPushPermissionService()
     private var rewardedInterstitial: RewardedInterstitialAd?
     private var didEarnRecoveryReward = false
     private var recoveryTransitionOverlay: UIView?
+    
+    private enum HomeModalKind {
+        case notificationPermission
+        case recoveryStreak
+    }
     
     // MARK: - Life Cycle
     
@@ -150,7 +156,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
                     with: monthInfo.recoveredDates
                 )
                 self.fetchAndShowDateInfo(for: self.homeView.calendarView.selectedDate ?? Date())
-                self.showRecoveryModalIfNeeded()
+                self.presentActiveHomeModalIfNeeded()
             }
             .store(in: &viewModel.cancellables)
         
@@ -293,54 +299,64 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
     }
 
     private func presentNotificationPermissionModal(on window: UIWindow) {
-        let modalView = NotificationPermissionModalView()
-        window.addSubview(modalView)
-        modalView.snp.makeConstraints { $0.edges.equalToSuperview() }
-        modalView.configure(
-            laterAction: { [weak modalView] in
+        guard notificationPermissionModal.superview == nil else { return }
+
+        window.addSubview(notificationPermissionModal)
+        notificationPermissionModal.snp.makeConstraints { $0.edges.equalToSuperview() }
+
+        if let bottomSheet = onboardingBottomSheet {
+            window.bringSubviewToFront(bottomSheet)
+        }
+
+        notificationPermissionModal.configure(
+            laterAction: { [weak self] in
                 AppVersionChecker.markAsShown()
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    modalView?.removeFromSuperview()
+                    self?.notificationPermissionModal.removeFromSuperview()
                 }
             },
-            enableAction: { [weak modalView, weak self] in
+            enableAction: { [weak self] in
                 AppVersionChecker.markAsShown()
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    modalView?.removeFromSuperview()
+                    self?.notificationPermissionModal.removeFromSuperview()
                     self?.openSystemSettings()
                 }
             }
         )
-        modalView.dialog.showAnimation()
+        notificationPermissionModal.dialog.showAnimation()
     }
     
     private func showOnboardingBottomSheet() {
         guard UserDefaults.standard.bool(forKey: "showHomeOnboarding") else { return }
-
         guard !hasShownOnboardingBottomSheet else { return }
+
         hasShownOnboardingBottomSheet = true
         isShowingOnboardingBottomSheet = true
+        
+        UserDefaults.standard.set(false, forKey: "showHomeOnboarding")
 
         let bottomSheet = OnboardingBottomSheet()
         onboardingBottomSheet = bottomSheet
         bottomSheet.onDismiss = { [weak self] in
             guard let self else { return }
+
             self.onboardingBottomSheet = nil
             self.isShowingOnboardingBottomSheet = false
-            self.showNextHomeModal()
+
+            DispatchQueue.main.async {
+                self.showNextHomeModal()
+            }
         }
 
         view.window?.addSubview(bottomSheet)
         bottomSheet.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-
-        UserDefaults.standard.set(false, forKey: "showHomeOnboarding")
     }
     
     private func showNextHomeModal() {
         guard !isHomeModalVisible else { return }
-        showRecoveryModalIfNeeded()
+        presentActiveHomeModalIfNeeded()
     }
     
     private func finishRecoveryWritingFlowIfNeeded() {
@@ -352,41 +368,49 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         isRecoveryWritingFlowActive = false
     }
     
-    private func showUpdateNoticeModalIfNeeded() -> Bool {
-        guard !isShowingOnboardingBottomSheet,
-              let window = view.window,
-              shouldShowUpdateNoticeModal() else { return false }
-        
-        markUpdateNoticeModalAsShown()
-        updateNoticeModal.onDismiss = { [weak self] in
-            self?.showRecoveryModalIfNeeded()
+    private func presentActiveHomeModalIfNeeded() {
+        guard let window = view.window,
+              !isHomeModalVisible else { return }
+
+        switch activeHomeModal {
+        case .notificationPermission:
+            showNotificationPermissionModalIfNeeded()
+
+        case .recoveryStreak:
+            let today = Date()
+            let selectedDate = homeView.calendarView.selectedDate ?? today
+            guard canShowRecoveryModal(today: today, selectedDate: selectedDate),
+                  let date = mostRecentRecoveryViewDateInCurrentMonth() else { return }
+            showRecoveryModal(for: date)
         }
-        window.addSubview(updateNoticeModal)
-        updateNoticeModal.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-        
-        updateNoticeModal.isHidden = false
-        updateNoticeModal.configure(
-            title: "이제 끊긴 기록을 되살릴 수 있어요!",
-            subtitle: "미처 작성하지 못한 날짜를 누르고,\n광고 한 편 보고 끊긴 기록을 살려보세요.",
-            image: UIImage(resource: .imgModalUpdateIos),
-            buttonTitle: "확인했습니다",
-            buttonText: nil,
-            buttonAction: { [weak self] in
-                self?.updateNoticeModal.dismissModal()
+    }
+    
+    private func showNotificationPermissionModalIfNeeded() {
+        guard shouldShowNotificationPermissionModal() else { return }
+
+        Task {
+            let isGranted = await fetchNotificationPermission()
+
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                guard !isGranted else {
+                    self.markNotificationPermissionModalAsShown()
+                    return
+                }
+                guard let window = self.view.window else { return }
+
+                self.markNotificationPermissionModalAsShown()
+                self.presentNotificationPermissionModal(on: window)
             }
-        )
-        updateNoticeModal.showAnimation()
-        return true
+        }
     }
     
-    private func shouldShowUpdateNoticeModal() -> Bool {
-        !UserDefaults.standard.bool(forKey: didShowUpdateNoticeModalStorageKey)
+    private func shouldShowNotificationPermissionModal() -> Bool {
+        !UserDefaults.standard.bool(forKey: didShowNotificationPermissionModalStorageKey)
     }
     
-    private func markUpdateNoticeModalAsShown() {
-        UserDefaults.standard.set(true, forKey: didShowUpdateNoticeModalStorageKey)
+    private func markNotificationPermissionModalAsShown() {
+        UserDefaults.standard.set(true, forKey: didShowNotificationPermissionModalStorageKey)
     }
     
     private func dateKey(_ date: Date) -> String {
@@ -436,25 +460,9 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
         UserDefaults.standard.set(monthKey(Date()), forKey: dismissedRecoveryModalMonthStorageKey)
     }
     
-    private func showRecoveryModalIfNeeded() {
-        let today = Date()
-        let selectedDate = homeView.calendarView.selectedDate ?? today
-        
-        guard !isShowingOnboardingBottomSheet else { return }
-        guard !UserDefaults.standard.bool(forKey: "showHomeOnboarding") else { return }
-        guard canShowRecoveryModal(today: today, selectedDate: selectedDate) else { return }
-        guard let recoveryDate = mostRecentRecoveryViewDateInCurrentMonth() else { return }
-        guard !isHomeModalVisible else { return }
-        showRecoveryModal(for: recoveryDate)
-    }
-    
     private var isHomeModalVisible: Bool {
-        isShowingOnboardingBottomSheet
-        || (homeModal.superview != nil && !homeModal.isHidden)
-    }
-    
-    private var isUpdateNoticeModalVisible: Bool {
-        updateNoticeModal.superview != nil && !updateNoticeModal.isHidden
+        (homeModal.superview != nil && !homeModal.isHidden)
+        || (notificationPermissionModal.superview != nil && !notificationPermissionModal.isHidden)
     }
     
     private func canShowRecoveryModal(today: Date, selectedDate: Date) -> Bool {
@@ -1204,7 +1212,7 @@ public final class HomeViewController: BaseUIViewController<HomeViewModel> {
             fetchAndShowDateInfo(for: selectedDate)
         }
         if shouldShowRecoveryModal {
-            showRecoveryModalIfNeeded()
+            presentActiveHomeModalIfNeeded()
         }
     }
     


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #461 

---

## 📎 Work Description 
- HomeModalKind enum 구조를 도입하여 홈 화면 내 추가될 팝업 모달의 확장 및 교체가 용이하도록 모달 관리 방식을 개편했습니다.
- 신규 유저 온보딩 바텀시트와 모달 간의 화면 계층 구조 및 노출 타이밍을 정리했습니다.

## 📝 [코드 가이드] HomeModalKind 기반 모달 교체 및 추가 사용법(2026.08.01 업데이트🆕)
1️⃣ **기존 모달을 새로운 모달로 교체해서 사용하는 경우**
- VC의 렌더링 호출부만 교체
```
// HomeViewController.swift

// 1) 기존 모달 인스턴스 교체
private let updateNoticeModal = UpdateNoticeModalView()

// 2) switch문에서 렌더링 메서드 바인딩 교체
private func presentActiveHomeModalIfNeeded() {
    // ... guard문 생략
    guard let policy = HomeModalPolicy.evaluate(...) else { return }

    switch policy {
    case .notificationPermission:
        // 기존 알림 모달 대신 새로 만든 업데이트 안내 모달 호출
        presentUpdateNoticeModal(on: window) 

    case .recoveryStreak(let date):
        showRecoveryModal(for: date)
    }
}

```
2️⃣ **새로운 모달 타입을 Enum에 추가하여 확장하는 경우**
- HomeModalPolicy Enum에 케이스 및 조건 추가

```
// HomeModalPolicy.swift

enum HomeModalPolicy {
    case notificationPermission
    case recoveryStreak(Date)
    case eventNotice // 👈 1. 신규 모달 케이스 추가 (필요시 Associated Value 전달)

    static func evaluate(context: HomeModalContext, isNotificationPermissionModalShown: Bool) -> HomeModalPolicy? {
        // 1) 알림 권한 모달 최우선 노출
        if !isNotificationPermissionModalShown {
            return .notificationPermission
        }

        // 2) 신규 모달 노출 조건 검사 (예시)
        if shouldShowEventNotice(context: context) {
            return .eventNotice
        }

        // 3) 스트릭 복구 모달 조건 검사
        // ... (기존 스트릭 로직)

        return nil
    }
}
```

- HomeViewController에 모달 뷰 연결
```
// HomeViewController.swift

public final class HomeViewController: BaseUIViewController<HomeViewModel> {
    
    // 1) 신규 모달 인스턴스 선언
    private let eventNoticeModal = EventNoticeModalView()
    
    // 2) isHomeModalVisible 가시성 체크에 추가
    private var isHomeModalVisible: Bool {
        (homeModal.superview != nil && !homeModal.isHidden)
        || (notificationPermissionModal.superview != nil && !notificationPermissionModal.isHidden)
        || (eventNoticeModal.superview != nil && !eventNoticeModal.isHidden) // 👈 추가
    }
    
    // 3) Policy 결과를 받아 렌더링 분기 처리
    private func presentActiveHomeModalIfNeeded() {
        guard !isShowingOnboardingBottomSheet,
              !UserDefaults.standard.bool(forKey: "showHomeOnboarding"),
              let window = view.window,
              !isHomeModalVisible else { return }

        let context = currentHomeModalContext()
        let isShown = UserDefaults.standard.bool(forKey: didShowNotificationPermissionModalStorageKey)

        // Policy에서 노출할 모달을 결정 (없으면 nil 리턴)
        guard let policy = HomeModalPolicy.evaluate(context: context, isNotificationPermissionModalShown: isShown) else {
            return
        }

        switch policy {
        case .notificationPermission:
            showNotificationPermissionModalIfNeeded()

        case .recoveryStreak(let date):
            showRecoveryModal(for: date)

        case .eventNotice: // 👈 신규 케이스 분기 추가
            presentEventNoticeModal(on: window)
        }
    }

    // 4) 신규 모달 렌더링 메서드 작성 (바텀시트 위계 보장)
    private func presentEventNoticeModal(on window: UIWindow) {
        guard eventNoticeModal.superview == nil else { return }

        window.addSubview(eventNoticeModal)
        eventNoticeModal.snp.makeConstraints { $0.edges.equalToSuperview() }

        if let bottomSheet = onboardingBottomSheet {
            window.bringSubviewToFront(bottomSheet)
        }

        eventNoticeModal.configure(
            dismissAction: { [weak self] in
                self?.eventNoticeModal.removeFromSuperview()
            }
        )
        eventNoticeModal.dialog.showAnimation()
    }
}
```

---

## 📷 Screenshots  

| 기능/화면 | 신규 유저 | 기존 유저 |
|:---------:|:---------:|:-------------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/073cca63-b756-4b33-9ddd-7d6ed235f311" width="250"> | <img src="https://github.com/user-attachments/assets/973e8835-fadd-4388-a40b-776b702dc0bc" width="250"> |

---

## 💬 To Reviewers  
- 처음 팝업 교체할 때 까다로웠던 기억이 있어서, 최대한 쉽게 사용할 수 있도록 방식을 변경했습니다 ! 
[2026.08.01 업데이트] 사용방법 제미나이선생님한테 정리해달라고 햇으니, 위 코드 참고하셔서 사용해주세요 !!
- 더 좋은 방법 있으면 피드백 환영입니다 🙌🏻
