### PR TITLE
[fix] 캘린더 오늘 날짜 dot 표시 문제 수정

### DIFF
--- a/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarContentView.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CalendarContentView.swift
@@ -52,7 +52,7 @@ final class CalendarContentView: UICollectionView {
     init() {
         let layout = UICollectionViewFlowLayout()
         layout.minimumInteritemSpacing = 0
-        layout.minimumLineSpacing = 14
+        layout.minimumLineSpacing = 6
         layout.estimatedItemSize = .zero
 
         super.init(frame: .zero, collectionViewLayout: layout)
@@ -147,7 +147,7 @@ final class CalendarContentView: UICollectionView {
         guard width > 0 else { return }
 
         (collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize =
-            CGSize(width: width, height: 34)
+            CGSize(width: width, height: 42)
     }
 }
 
@@ -232,8 +232,8 @@ extension CalendarContentView {
     }
 
     override var intrinsicContentSize: CGSize {
-        let rowHeight: CGFloat = 34
-        let lineSpacing: CGFloat = 14
+        let rowHeight: CGFloat = 42
+        let lineSpacing: CGFloat = 6
 
         let height =
             CGFloat(rowCount) * rowHeight +

--- a/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CustomCalendarCell.swift
+++ b/HilingualPresentation/Sources/Presentation/Common/Components/Calendar/CustomCalendarCell.swift
@@ -45,12 +45,12 @@ final class CustomCalendarCell: UICollectionViewCell {
 
     private func setupLayout() {
         bubbleView.snp.makeConstraints {
-            $0.center.equalToSuperview()
+            $0.top.centerX.equalToSuperview()
             $0.size.equalTo(34)
         }
 
         dayLabel.snp.makeConstraints {
-            $0.center.equalToSuperview()
+            $0.center.equalTo(bubbleView)
         }
 
         dotView.snp.makeConstraints {


### PR DESCRIPTION
## ✅ Check List
- [ ] merge할 브랜치의 위치를 확인해 주세요.(main❌/develop⭕)
- [ ] 2인 이상의 Approve를 받은 후 머지해주세요.
- [ ] 변경사항은 500줄 이하로 유지해주세요.
- [ ] PR에는 핵심 내용만 적고, 자세한 내용은 트슈에 작성한 뒤 링크를 공유해주세요.
- [ ] Approve된 PR은 Assigner가 직접 머지해주세요.
- [ ] 수정 요청이 있다면 반영 후 다시 push해주세요.

---

## 📌 Related Issue  
- closed #470 

---

## 📎 Work Description 
- 캘린더 오늘 날짜 표시 dot이 보이지 않던 문제를 수정했습니다.
- dotView가 셀 bounds 밖으로 나가지 않도록 캘린더 셀 높이를 조정했습니다.
- 기존 날짜 버블 간 세로 간격은 유지되도록 line spacing을 함께 조정했습니다.

---

## 📷 Screenshots  

| 기능/화면 | iPhone 17 Pro |
|:---------:|:---------:|
| A 기능 | <img src="https://github.com/user-attachments/assets/9d100a70-0f55-401c-ad69-179e9840d61d" width="250"> | 

---

## 💬 To Reviewers  
- 리뷰어에게 전달하고 싶은 메시지를 남겨주세요.
